### PR TITLE
State Registry - Decouple State fields from runtime logic

### DIFF
--- a/src/finance/account-rules/au/au-super-classes.js
+++ b/src/finance/account-rules/au/au-super-classes.js
@@ -143,17 +143,18 @@ export class SuperEarningsApplyReducer extends Reducer {
   }
 
   reduce(state, action) {
-    const sa = state.superAccount;
+    const key = action.stateKey ?? 'superAccount';
+    const sa = state[key];
     return this.newState(
       state,
       {
-        superAccount: {
+        [key]: {
           ...sa,
           balance:       sa.balance       + action.amount,
           earningsBasis: sa.earningsBasis + action.amount,
         },
       },
-      [{ type: 'SUPER_EARNINGS_TAX', amount: action.amount }]
+      [{ type: 'SUPER_EARNINGS_TAX', amount: action.amount, stateKey: key }]
     );
   }
 }

--- a/src/finance/account-rules/us/ira-classes.js
+++ b/src/finance/account-rules/us/ira-classes.js
@@ -138,9 +138,10 @@ export class IraEarningsApplyReducer extends Reducer {
   }
 
   reduce(state, action) {
-    const ia = state.iraAccount;
+    const key = action.stateKey ?? 'iraAccount';
+    const ia = state[key];
     return this.newState(state, {
-      iraAccount: {
+      [key]: {
         ...ia,
         balance:       ia.balance       + action.amount,
         earningsBasis: ia.earningsBasis + action.amount,

--- a/src/finance/account-rules/us/k401-classes.js
+++ b/src/finance/account-rules/us/k401-classes.js
@@ -68,9 +68,10 @@ export class K401EarningsApplyReducer extends Reducer {
   }
 
   reduce(state, action) {
-    const ka = state.k401Account;
+    const key = action.stateKey ?? 'k401Account';
+    const ka = state[key];
     return this.newState(state, {
-      k401Account: {
+      [key]: {
         ...ka,
         balance:       ka.balance       + action.amount,
         earningsBasis: ka.earningsBasis + action.amount,

--- a/src/finance/account-rules/us/roth-classes.js
+++ b/src/finance/account-rules/us/roth-classes.js
@@ -124,9 +124,10 @@ export class RothEarningsApplyReducer extends Reducer {
   }
 
   reduce(state, action) {
-    const ra = state.rothAccount;
+    const key = action.stateKey ?? 'rothAccount';
+    const ra = state[key];
     return this.newState(state, {
-      rothAccount: {
+      [key]: {
         ...ra,
         balance:       ra.balance       + action.amount,
         earningsBasis: ra.earningsBasis + action.amount,

--- a/src/finance/account-rules/us/us-brokerage-classes.js
+++ b/src/finance/account-rules/us/us-brokerage-classes.js
@@ -105,9 +105,9 @@ export class StockContributionApplyReducer extends Reducer {
 
   reduce(state, action) {
     this.accountService.transaction(usCash(state), -action.amount, null);
-    const sa = state.stockAccount;
+    const sa = state.usStockAccount;
     return this.newState(state, {
-      stockAccount: {
+      usStockAccount: {
         ...sa,
         balance:           sa.balance           + action.amount,
         contributionBasis: sa.contributionBasis + action.amount,
@@ -132,11 +132,11 @@ export class StockDividendApplyReducer extends Reducer {
 
   reduce(state, action) {
     const { amount, isAuResident } = action;
-    const sa = state.stockAccount;
+    const sa = state.usStockAccount;
     return this.newState(
       state,
       {
-        stockAccount: {
+        usStockAccount: {
           ...sa,
           balance:           sa.balance           + amount,
           contributionBasis: sa.contributionBasis + amount,
@@ -159,9 +159,9 @@ export class StockEarningsApplyReducer extends Reducer {
   }
 
   reduce(state, action) {
-    const sa = state.stockAccount;
+    const sa = state.usStockAccount;
     return this.newState(state, {
-      stockAccount: {
+      usStockAccount: {
         ...sa,
         balance:       sa.balance       + action.amount,
         earningsBasis: sa.earningsBasis + action.amount,
@@ -189,14 +189,14 @@ export class StockWithdrawalApplyReducer extends Reducer {
     const { salePrice, costBasis, isAuResident } = action;
     const gain = Math.max(0, salePrice - costBasis);
     this.accountService.transaction(usCash(state), salePrice, null);
-    const sa = state.stockAccount;
+    const sa = state.usStockAccount;
     const newBalance  = sa.balance - salePrice;
     const newEarnings = Math.max(0, sa.earningsBasis - gain);
     const newContrib  = newBalance - newEarnings;
     return this.newState(
       state,
       {
-        stockAccount: {
+        usStockAccount: {
           ...sa,
           balance:           newBalance,
           contributionBasis: newContrib,
@@ -273,7 +273,7 @@ export class StockContributionHandler extends HandlerEntry {
   call({ data }) {
     return [
       { type: 'STOCK_CONTRIBUTION_APPLY', amount: data.amount },
-      new RecordBalanceAction('stockAccount.balance', 'stockAccount'),
+      new RecordBalanceAction('usStockAccount.balance', 'usStockAccount'),
     ];
   }
 }
@@ -290,7 +290,7 @@ export class StockDividendHandler extends HandlerEntry {
   call({ data, state }) {
     return [
       { type: 'STOCK_DIVIDEND_APPLY', amount: data.amount, isAuResident: state.isAuResident },
-      new RecordBalanceAction('stockAccount.balance', 'stockAccount'),
+      new RecordBalanceAction('usStockAccount.balance', 'usStockAccount'),
     ];
   }
 }
@@ -307,7 +307,7 @@ export class StockEarningsHandler extends HandlerEntry {
   call({ data }) {
     return [
       { type: 'STOCK_EARNINGS_APPLY', amount: data.amount },
-      new RecordBalanceAction('stockAccount.balance', 'stockAccount'),
+      new RecordBalanceAction('usStockAccount.balance', 'usStockAccount'),
     ];
   }
 }
@@ -329,7 +329,7 @@ export class StockWithdrawalHandler extends HandlerEntry {
         costBasis:    data.costBasis,
         isAuResident: state.isAuResident,
       },
-      new RecordBalanceAction('stockAccount.balance', 'stockAccount'),
+      new RecordBalanceAction('usStockAccount.balance', 'usStockAccount'),
     ];
   }
 }

--- a/src/finance/assets/account.js
+++ b/src/finance/assets/account.js
@@ -84,6 +84,7 @@ export class Account extends Asset {
    * @param {object} [opts]
    * @param {string|null}   [opts.id=null]               - Assigned by AccountService; null until registered
    * @param {string}        [opts.name='']               - Display name for UI
+   * @param {string|null}   [opts.role=null]             - Semantic role (ACCOUNT_ROLES value); used by StateRegistry lookups
    * @param {string|null}   [opts.type=null]             - Account type discriminator (ACCOUNT_TYPE value)
    * @param {string}        [opts.ownershipType='sole']  - 'sole' | 'joint' (inherited from Asset)
    * @param {string|null}   [opts.ownerId=null]          - Person id of primary owner (inherited from Asset)
@@ -94,6 +95,7 @@ export class Account extends Asset {
    */
   constructor(initialValue = 0, opts = {}) {
     super(opts.name ?? '', { ...opts, kind: 'account' });
+    this.role           = opts.role           ?? null;
     this.type           = opts.type           ?? null;
     this.balance        = initialValue;
     this.minimumBalance = opts.minimumBalance ?? 0;

--- a/src/finance/handlers/dividend-scheduled-handler.js
+++ b/src/finance/handlers/dividend-scheduled-handler.js
@@ -28,31 +28,33 @@ import { RecordBalanceAction, RecordMetricAction } from '../../simulation-framew
  * data.reinvest overrides the configured reinvest param for one-off events.
  *
  * @param {object} [opts]
- * @param {string} [opts.accountKey='usStockAccount']
- *   State key for the stock account whose balance drives the calculation.
+ * @param {import('../services/state-registry.js').StateRegistry} opts.stateRegistry
+ * @param {string} opts.role       - ACCOUNT_ROLES value for the stock account
+ * @param {string} [opts.ownerId]  - Person id (null = any owner)
  * @param {number} [opts.dividendRate=0.02]
- *   Annual dividend yield (e.g. 0.02 = 2%).
  * @param {boolean} [opts.reinvest=false]
- *   Default reinvestment flag; data.reinvest overrides per event.
  */
 export class DividendScheduledHandler extends HandlerEntry {
   static description = 'Computes stock dividends from balance × dividendRate and routes to STOCK_DIVIDEND_APPLY (reinvest) or STOCK_DIVIDEND_CASH_APPLY (cash payout).';
 
   static eventType = 'DIVIDEND_SCHEDULED';
 
-  constructor({ accountKey = 'usStockAccount', dividendRate = 0.02, reinvest = false } = {}) {
+  constructor({ stateRegistry, role, ownerId = null, dividendRate = 0.02, reinvest = false } = {}) {
     super(null, 'Dividend Scheduled');
-    this.accountKey   = accountKey;
-    this.dividendRate = dividendRate;
-    this.reinvest     = reinvest;
+    this.stateRegistry = stateRegistry;
+    this.role          = role;
+    this.ownerId       = ownerId;
+    this.dividendRate  = dividendRate;
+    this.reinvest      = reinvest;
     // Declares both branches; actual type chosen at runtime based on reinvest flag
     this.generatedActionTypes = ['STOCK_DIVIDEND_APPLY', 'STOCK_DIVIDEND_CASH_APPLY', 'RECORD_METRIC', 'RECORD_BALANCE'];
   }
 
   call({ data, state }) {
-    const balance = state[this.accountKey]?.balance ?? 0;
-    const amount  = +(balance * this.dividendRate).toFixed(2);
-    if (amount <= 0) return [new RecordBalanceAction(`${this.accountKey}.balance`, this.accountKey)];
+    const stateKey = this.stateRegistry.getStateKey(this.role, this.ownerId);
+    const balance  = this.stateRegistry.getAccount(state, this.role, this.ownerId)?.balance ?? 0;
+    const amount   = +(balance * this.dividendRate).toFixed(2);
+    if (amount <= 0) return [new RecordBalanceAction(`${stateKey}.balance`, stateKey)];
 
     const reinvest     = data?.reinvest ?? this.reinvest;
     const isAuResident = state.isAuResident;
@@ -61,7 +63,7 @@ export class DividendScheduledHandler extends HandlerEntry {
     return [
       { type: actionType, amount, isAuResident },
       new RecordMetricAction('dividends', amount),
-      new RecordBalanceAction(`${this.accountKey}.balance`, this.accountKey),
+      new RecordBalanceAction(`${stateKey}.balance`, stateKey),
     ];
   }
 }

--- a/src/finance/handlers/dividend-scheduled-handler.js
+++ b/src/finance/handlers/dividend-scheduled-handler.js
@@ -28,7 +28,7 @@ import { RecordBalanceAction, RecordMetricAction } from '../../simulation-framew
  * data.reinvest overrides the configured reinvest param for one-off events.
  *
  * @param {object} [opts]
- * @param {string} [opts.accountKey='stockAccount']
+ * @param {string} [opts.accountKey='usStockAccount']
  *   State key for the stock account whose balance drives the calculation.
  * @param {number} [opts.dividendRate=0.02]
  *   Annual dividend yield (e.g. 0.02 = 2%).
@@ -40,7 +40,7 @@ export class DividendScheduledHandler extends HandlerEntry {
 
   static eventType = 'DIVIDEND_SCHEDULED';
 
-  constructor({ accountKey = 'stockAccount', dividendRate = 0.02, reinvest = false } = {}) {
+  constructor({ accountKey = 'usStockAccount', dividendRate = 0.02, reinvest = false } = {}) {
     super(null, 'Dividend Scheduled');
     this.accountKey   = accountKey;
     this.dividendRate = dividendRate;

--- a/src/finance/handlers/earnings-handlers.js
+++ b/src/finance/handlers/earnings-handlers.js
@@ -34,7 +34,7 @@ export class IntlRothEarningsHandler extends HandlerEntry {
     const amount   = +(balance * this.growthRate).toFixed(2);
     if (amount <= 0) return [new RecordBalanceAction(`${stateKey}.balance`, stateKey)];
     return [
-      { type: 'ROTH_EARNINGS_APPLY', amount },
+      { type: 'ROTH_EARNINGS_APPLY', amount, stateKey },
       new RecordMetricAction('roth_earnings', amount),
       new RecordBalanceAction(`${stateKey}.balance`, stateKey),
     ];
@@ -64,7 +64,7 @@ export class IntlIraEarningsHandler extends HandlerEntry {
     const amount   = +(balance * this.growthRate).toFixed(2);
     if (amount <= 0) return [new RecordBalanceAction(`${stateKey}.balance`, stateKey)];
     return [
-      { type: 'IRA_EARNINGS_APPLY', amount },
+      { type: 'IRA_EARNINGS_APPLY', amount, stateKey },
       new RecordMetricAction('ira_earnings', amount),
       new RecordBalanceAction(`${stateKey}.balance`, stateKey),
     ];
@@ -94,7 +94,7 @@ export class IntlK401EarningsHandler extends HandlerEntry {
     const amount   = +(balance * this.growthRate).toFixed(2);
     if (amount <= 0) return [new RecordBalanceAction(`${stateKey}.balance`, stateKey)];
     return [
-      { type: 'K401_EARNINGS_APPLY', amount },
+      { type: 'K401_EARNINGS_APPLY', amount, stateKey },
       new RecordMetricAction('k401_earnings', amount),
       new RecordBalanceAction(`${stateKey}.balance`, stateKey),
     ];
@@ -318,7 +318,7 @@ export class SuperEarningsHandler extends HandlerEntry {
     const amount   = +(balance * rate).toFixed(2);
     if (amount <= 0) return [new RecordBalanceAction(`${stateKey}.balance`, stateKey)];
     return [
-      { type: 'SUPER_EARNINGS_APPLY', amount },
+      { type: 'SUPER_EARNINGS_APPLY', amount, stateKey },
       new RecordMetricAction('super_earnings', amount),
       new RecordBalanceAction(`${stateKey}.balance`, stateKey),
     ];

--- a/src/finance/handlers/earnings-handlers.js
+++ b/src/finance/handlers/earnings-handlers.js
@@ -101,7 +101,7 @@ export class IntlUsStockEarningsHandler extends HandlerEntry {
   static description = 'Computes annual unrealized appreciation on the US stock account (balance × growthRate) and dispatches STOCK_EARNINGS_APPLY.';
   static eventType = 'INTL_STOCK_EARNINGS';
 
-  constructor({ accountKey = 'stockAccount', growthRate = 0.05 } = {}) {
+  constructor({ accountKey = 'usStockAccount', growthRate = 0.05 } = {}) {
     super(null, 'US Stock Earnings');
     this.accountKey = accountKey;
     this.growthRate = growthRate;

--- a/src/finance/handlers/earnings-handlers.js
+++ b/src/finance/handlers/earnings-handlers.js
@@ -19,21 +19,24 @@ export class IntlRothEarningsHandler extends HandlerEntry {
   static description = 'Computes annual growth on the Roth IRA (balance × growthRate) and dispatches ROTH_EARNINGS_APPLY.';
   static eventType = 'INTL_ROTH_EARNINGS';
 
-  constructor({ accountKey = 'rothAccount', growthRate = 0.07 } = {}) {
+  constructor({ stateRegistry, role, ownerId = null, growthRate = 0.07 } = {}) {
     super(null, 'Roth IRA Earnings');
-    this.accountKey = accountKey;
-    this.growthRate = growthRate;
+    this.stateRegistry = stateRegistry;
+    this.role          = role;
+    this.ownerId       = ownerId;
+    this.growthRate    = growthRate;
     this.generatedActionTypes = ['ROTH_EARNINGS_APPLY', 'RECORD_METRIC', 'RECORD_BALANCE'];
   }
 
   call({ state }) {
-    const balance = state[this.accountKey]?.balance ?? 0;
-    const amount  = +(balance * this.growthRate).toFixed(2);
-    if (amount <= 0) return [new RecordBalanceAction(`${this.accountKey}.balance`, this.accountKey)];
+    const stateKey = this.stateRegistry.getStateKey(this.role, this.ownerId);
+    const balance  = this.stateRegistry.getAccount(state, this.role, this.ownerId)?.balance ?? 0;
+    const amount   = +(balance * this.growthRate).toFixed(2);
+    if (amount <= 0) return [new RecordBalanceAction(`${stateKey}.balance`, stateKey)];
     return [
       { type: 'ROTH_EARNINGS_APPLY', amount },
       new RecordMetricAction('roth_earnings', amount),
-      new RecordBalanceAction(`${this.accountKey}.balance`, this.accountKey),
+      new RecordBalanceAction(`${stateKey}.balance`, stateKey),
     ];
   }
 }
@@ -46,21 +49,24 @@ export class IntlIraEarningsHandler extends HandlerEntry {
   static description = 'Computes annual growth on the Traditional IRA (balance × growthRate) and dispatches IRA_EARNINGS_APPLY.';
   static eventType = 'INTL_IRA_EARNINGS';
 
-  constructor({ accountKey = 'iraAccount', growthRate = 0.07 } = {}) {
+  constructor({ stateRegistry, role, ownerId = null, growthRate = 0.07 } = {}) {
     super(null, 'IRA Earnings');
-    this.accountKey = accountKey;
-    this.growthRate = growthRate;
+    this.stateRegistry = stateRegistry;
+    this.role          = role;
+    this.ownerId       = ownerId;
+    this.growthRate    = growthRate;
     this.generatedActionTypes = ['IRA_EARNINGS_APPLY', 'RECORD_METRIC', 'RECORD_BALANCE'];
   }
 
   call({ state }) {
-    const balance = state[this.accountKey]?.balance ?? 0;
-    const amount  = +(balance * this.growthRate).toFixed(2);
-    if (amount <= 0) return [new RecordBalanceAction(`${this.accountKey}.balance`, this.accountKey)];
+    const stateKey = this.stateRegistry.getStateKey(this.role, this.ownerId);
+    const balance  = this.stateRegistry.getAccount(state, this.role, this.ownerId)?.balance ?? 0;
+    const amount   = +(balance * this.growthRate).toFixed(2);
+    if (amount <= 0) return [new RecordBalanceAction(`${stateKey}.balance`, stateKey)];
     return [
       { type: 'IRA_EARNINGS_APPLY', amount },
       new RecordMetricAction('ira_earnings', amount),
-      new RecordBalanceAction(`${this.accountKey}.balance`, this.accountKey),
+      new RecordBalanceAction(`${stateKey}.balance`, stateKey),
     ];
   }
 }
@@ -73,21 +79,24 @@ export class IntlK401EarningsHandler extends HandlerEntry {
   static description = 'Computes annual growth on the 401k (balance × growthRate) and dispatches K401_EARNINGS_APPLY.';
   static eventType = 'INTL_K401_EARNINGS';
 
-  constructor({ accountKey = 'k401Account', growthRate = 0.07 } = {}) {
+  constructor({ stateRegistry, role, ownerId = null, growthRate = 0.07 } = {}) {
     super(null, '401k Earnings');
-    this.accountKey = accountKey;
-    this.growthRate = growthRate;
+    this.stateRegistry = stateRegistry;
+    this.role          = role;
+    this.ownerId       = ownerId;
+    this.growthRate    = growthRate;
     this.generatedActionTypes = ['K401_EARNINGS_APPLY', 'RECORD_METRIC', 'RECORD_BALANCE'];
   }
 
   call({ state }) {
-    const balance = state[this.accountKey]?.balance ?? 0;
-    const amount  = +(balance * this.growthRate).toFixed(2);
-    if (amount <= 0) return [new RecordBalanceAction(`${this.accountKey}.balance`, this.accountKey)];
+    const stateKey = this.stateRegistry.getStateKey(this.role, this.ownerId);
+    const balance  = this.stateRegistry.getAccount(state, this.role, this.ownerId)?.balance ?? 0;
+    const amount   = +(balance * this.growthRate).toFixed(2);
+    if (amount <= 0) return [new RecordBalanceAction(`${stateKey}.balance`, stateKey)];
     return [
       { type: 'K401_EARNINGS_APPLY', amount },
       new RecordMetricAction('k401_earnings', amount),
-      new RecordBalanceAction(`${this.accountKey}.balance`, this.accountKey),
+      new RecordBalanceAction(`${stateKey}.balance`, stateKey),
     ];
   }
 }
@@ -101,21 +110,24 @@ export class IntlUsStockEarningsHandler extends HandlerEntry {
   static description = 'Computes annual unrealized appreciation on the US stock account (balance × growthRate) and dispatches STOCK_EARNINGS_APPLY.';
   static eventType = 'INTL_STOCK_EARNINGS';
 
-  constructor({ accountKey = 'usStockAccount', growthRate = 0.05 } = {}) {
+  constructor({ stateRegistry, role, ownerId = null, growthRate = 0.05 } = {}) {
     super(null, 'US Stock Earnings');
-    this.accountKey = accountKey;
-    this.growthRate = growthRate;
+    this.stateRegistry = stateRegistry;
+    this.role          = role;
+    this.ownerId       = ownerId;
+    this.growthRate    = growthRate;
     this.generatedActionTypes = ['STOCK_EARNINGS_APPLY', 'RECORD_METRIC', 'RECORD_BALANCE'];
   }
 
   call({ state }) {
-    const balance = state[this.accountKey]?.balance ?? 0;
-    const amount  = +(balance * this.growthRate).toFixed(2);
-    if (amount <= 0) return [new RecordBalanceAction(`${this.accountKey}.balance`, this.accountKey)];
+    const stateKey = this.stateRegistry.getStateKey(this.role, this.ownerId);
+    const balance  = this.stateRegistry.getAccount(state, this.role, this.ownerId)?.balance ?? 0;
+    const amount   = +(balance * this.growthRate).toFixed(2);
+    if (amount <= 0) return [new RecordBalanceAction(`${stateKey}.balance`, stateKey)];
     return [
       { type: 'STOCK_EARNINGS_APPLY', amount },
       new RecordMetricAction('us_stock_earnings', amount),
-      new RecordBalanceAction(`${this.accountKey}.balance`, this.accountKey),
+      new RecordBalanceAction(`${stateKey}.balance`, stateKey),
     ];
   }
 }
@@ -129,21 +141,24 @@ export class IntlAuStockEarningsHandler extends HandlerEntry {
   static description = 'Computes annual unrealized appreciation on the AU stock account (balance × growthRate) and dispatches AU_STOCK_EARNINGS_APPLY.';
   static eventType = 'INTL_AU_STOCK_EARNINGS';
 
-  constructor({ accountKey = 'auStockAccount', growthRate = 0.06 } = {}) {
+  constructor({ stateRegistry, role, ownerId = null, growthRate = 0.06 } = {}) {
     super(null, 'AU Stock Earnings');
-    this.accountKey = accountKey;
-    this.growthRate = growthRate;
+    this.stateRegistry = stateRegistry;
+    this.role          = role;
+    this.ownerId       = ownerId;
+    this.growthRate    = growthRate;
     this.generatedActionTypes = ['AU_STOCK_EARNINGS_APPLY', 'RECORD_METRIC', 'RECORD_BALANCE'];
   }
 
   call({ state }) {
-    const balance = state[this.accountKey]?.balance ?? 0;
-    const amount  = +(balance * this.growthRate).toFixed(2);
-    if (amount <= 0) return [new RecordBalanceAction(`${this.accountKey}.balance`, this.accountKey)];
+    const stateKey = this.stateRegistry.getStateKey(this.role, this.ownerId);
+    const balance  = this.stateRegistry.getAccount(state, this.role, this.ownerId)?.balance ?? 0;
+    const amount   = +(balance * this.growthRate).toFixed(2);
+    if (amount <= 0) return [new RecordBalanceAction(`${stateKey}.balance`, stateKey)];
     return [
       { type: 'AU_STOCK_EARNINGS_APPLY', amount },
       new RecordMetricAction('au_stock_earnings', amount),
-      new RecordBalanceAction(`${this.accountKey}.balance`, this.accountKey),
+      new RecordBalanceAction(`${stateKey}.balance`, stateKey),
     ];
   }
 }
@@ -159,10 +174,12 @@ export class IntlAuStockDividendHandler extends HandlerEntry {
   static description = 'Computes annual AU stock dividends (balance × dividendRate) and routes to the franked-resident or franked-non-resident apply action based on residency.';
   static eventType = 'INTL_AU_STOCK_DIVIDEND';
 
-  constructor({ accountKey = 'auStockAccount', dividendRate = 0.04 } = {}) {
+  constructor({ stateRegistry, role, ownerId = null, dividendRate = 0.04 } = {}) {
     super(null, 'AU Stock Dividend');
-    this.accountKey   = accountKey;
-    this.dividendRate = dividendRate;
+    this.stateRegistry = stateRegistry;
+    this.role          = role;
+    this.ownerId       = ownerId;
+    this.dividendRate  = dividendRate;
     this.generatedActionTypes = [
       'AU_DIVIDEND_FRANKED_RESIDENT_APPLY',
       'AU_DIVIDEND_FRANKED_NONRESIDENT_APPLY',
@@ -172,9 +189,10 @@ export class IntlAuStockDividendHandler extends HandlerEntry {
   }
 
   call({ state }) {
-    const balance = state[this.accountKey]?.balance ?? 0;
-    const amount  = +(balance * this.dividendRate).toFixed(2);
-    if (amount <= 0) return [new RecordBalanceAction(`${this.accountKey}.balance`, this.accountKey)];
+    const stateKey = this.stateRegistry.getStateKey(this.role, this.ownerId);
+    const balance  = this.stateRegistry.getAccount(state, this.role, this.ownerId)?.balance ?? 0;
+    const amount   = +(balance * this.dividendRate).toFixed(2);
+    if (amount <= 0) return [new RecordBalanceAction(`${stateKey}.balance`, stateKey)];
 
     const actionType = state.isAuResident
       ? 'AU_DIVIDEND_FRANKED_RESIDENT_APPLY'
@@ -183,7 +201,7 @@ export class IntlAuStockDividendHandler extends HandlerEntry {
     return [
       { type: actionType, amount },
       new RecordMetricAction('au_stock_dividend', amount),
-      new RecordBalanceAction(`${this.accountKey}.balance`, this.accountKey),
+      new RecordBalanceAction(`${stateKey}.balance`, stateKey),
     ];
   }
 }
@@ -192,37 +210,37 @@ export class IntlAuStockDividendHandler extends HandlerEntry {
  * Handles INTL_AU_SAVINGS_INTEREST events.
  *
  * Computes annual interest as: balance × interestRate, rounded to 2 dp.
- * Emits AU_SAVINGS_EARNINGS_APPLY (registered by AuAccountModule) which
- * credits the account and chains AU_SAVINGS_EARNINGS_TAX.
- *
- * Uses the INTL_ prefix to avoid colliding with the account module's own
- * AU_SAVINGS_EARNINGS event handler (which expects data.amount to be provided
- * by the caller rather than computed from balance × rate).
+ * Emits AU_SAVINGS_EARNINGS_APPLY (registered by AuAccountModule).
  *
  * @param {object} [opts]
- * @param {string} [opts.accountKey='auSavingsAccount']
- * @param {number} [opts.interestRate=0.045] Annual interest rate (e.g. 0.045 = 4.5%)
+ * @param {import('../services/state-registry.js').StateRegistry} opts.stateRegistry
+ * @param {string} opts.role       - ACCOUNT_ROLES value for the AU savings account
+ * @param {string} [opts.ownerId]  - Person id (null = any owner)
+ * @param {number} [opts.interestRate=0.045]
  */
 export class AuSavingsInterestHandler extends HandlerEntry {
   static description = 'Computes annual interest on the AU savings account and emits AU_SAVINGS_EARNINGS_APPLY (credited by AuAccountModule).';
 
   static eventType = 'INTL_AU_SAVINGS_INTEREST';
 
-  constructor({ accountKey = 'auSavingsAccount', interestRate = 0.045 } = {}) {
+  constructor({ stateRegistry, role, ownerId = null, interestRate = 0.045 } = {}) {
     super(null, 'AU Savings Interest');
-    this.accountKey   = accountKey;
-    this.interestRate = interestRate;
+    this.stateRegistry = stateRegistry;
+    this.role          = role;
+    this.ownerId       = ownerId;
+    this.interestRate  = interestRate;
     this.generatedActionTypes = ['AU_SAVINGS_EARNINGS_APPLY', 'RECORD_METRIC', 'RECORD_BALANCE'];
   }
 
   call({ state }) {
-    const balance = state[this.accountKey]?.balance ?? 0;
-    const amount  = +(balance * this.interestRate).toFixed(2);
-    if (amount <= 0) return [new RecordBalanceAction(`${this.accountKey}.balance`, `${this.accountKey}`)];
+    const stateKey = this.stateRegistry.getStateKey(this.role, this.ownerId);
+    const balance  = this.stateRegistry.getAccount(state, this.role, this.ownerId)?.balance ?? 0;
+    const amount   = +(balance * this.interestRate).toFixed(2);
+    if (amount <= 0) return [new RecordBalanceAction(`${stateKey}.balance`, stateKey)];
     return [
       { type: 'AU_SAVINGS_EARNINGS_APPLY', amount, isAuResident: state.isAuResident },
       new RecordMetricAction('au_savings_interest', amount),
-      new RecordBalanceAction(`${this.accountKey}.balance`, `${this.accountKey}`),
+      new RecordBalanceAction(`${stateKey}.balance`, stateKey),
     ];
   }
 }
@@ -231,36 +249,37 @@ export class AuSavingsInterestHandler extends HandlerEntry {
  * Handles INTL_FIXED_INCOME_INTEREST events.
  *
  * Computes annual interest as: balance × interestRate, rounded to 2 dp.
- * Emits FIXED_INCOME_EARNINGS_APPLY (registered by UsAccountModule) which
- * credits the account and chains FIXED_INCOME_EARNINGS_TAX.
- *
- * Uses the INTL_ prefix to avoid colliding with the account module's own
- * FIXED_INCOME_EARNINGS handler.
+ * Emits FIXED_INCOME_EARNINGS_APPLY (registered by UsAccountModule).
  *
  * @param {object} [opts]
- * @param {string} [opts.accountKey='fixedIncomeAccount']
- * @param {number} [opts.interestRate=0.04] Annual interest rate (e.g. 0.04 = 4%)
+ * @param {import('../services/state-registry.js').StateRegistry} opts.stateRegistry
+ * @param {string} opts.role       - ACCOUNT_ROLES value for the fixed income account
+ * @param {string} [opts.ownerId]  - Person id (null = any owner)
+ * @param {number} [opts.interestRate=0.04]
  */
 export class FixedIncomeInterestHandler extends HandlerEntry {
   static description = 'Computes annual interest on the fixed income account and emits FIXED_INCOME_EARNINGS_APPLY (credited by UsAccountModule).';
 
   static eventType = 'INTL_FIXED_INCOME_INTEREST';
 
-  constructor({ accountKey = 'fixedIncomeAccount', interestRate = 0.04 } = {}) {
+  constructor({ stateRegistry, role, ownerId = null, interestRate = 0.04 } = {}) {
     super(null, 'Fixed Income Interest');
-    this.accountKey   = accountKey;
-    this.interestRate = interestRate;
+    this.stateRegistry = stateRegistry;
+    this.role          = role;
+    this.ownerId       = ownerId;
+    this.interestRate  = interestRate;
     this.generatedActionTypes = ['FIXED_INCOME_EARNINGS_APPLY', 'RECORD_METRIC', 'RECORD_BALANCE'];
   }
 
   call({ state }) {
-    const balance = state[this.accountKey]?.balance ?? 0;
-    const amount  = +(balance * this.interestRate).toFixed(2);
-    if (amount <= 0) return [new RecordBalanceAction(`${this.accountKey}.balance`, `${this.accountKey}`)];
+    const stateKey = this.stateRegistry.getStateKey(this.role, this.ownerId);
+    const balance  = this.stateRegistry.getAccount(state, this.role, this.ownerId)?.balance ?? 0;
+    const amount   = +(balance * this.interestRate).toFixed(2);
+    if (amount <= 0) return [new RecordBalanceAction(`${stateKey}.balance`, stateKey)];
     return [
       { type: 'FIXED_INCOME_EARNINGS_APPLY', amount, isAuResident: state.isAuResident },
       new RecordMetricAction('fixed_income_interest', amount),
-      new RecordBalanceAction(`${this.accountKey}.balance`, `${this.accountKey}`),
+      new RecordBalanceAction(`${stateKey}.balance`, stateKey),
     ];
   }
 }
@@ -270,37 +289,38 @@ export class FixedIncomeInterestHandler extends HandlerEntry {
  *
  * Computes annual earnings as: balance × rate, rounded to 2 dp.
  * data.rate overrides the configured defaultRate for one-off adjustments.
- * Emits SUPER_EARNINGS_APPLY (registered by AuAccountModule) which credits
- * both balance and earningsBasis, then chains SUPER_EARNINGS_TAX (15%).
- *
- * Uses the INTL_ prefix to avoid colliding with the account module's own
- * SUPER_EARNINGS handler.
+ * Emits SUPER_EARNINGS_APPLY (registered by AuAccountModule).
  *
  * @param {object} [opts]
- * @param {string} [opts.accountKey='superAccount']
- * @param {number} [opts.defaultRate=0.07] Default annual growth rate (e.g. 0.07 = 7%)
+ * @param {import('../services/state-registry.js').StateRegistry} opts.stateRegistry
+ * @param {string} opts.role       - ACCOUNT_ROLES value for the super account
+ * @param {string} [opts.ownerId]  - Person id (null = any owner)
+ * @param {number} [opts.defaultRate=0.07]
  */
 export class SuperEarningsHandler extends HandlerEntry {
   static description = 'Computes annual earnings on the superannuation account and emits SUPER_EARNINGS_APPLY (credited by AuAccountModule).';
 
   static eventType = 'INTL_SUPER_EARNINGS';
 
-  constructor({ accountKey = 'superAccount', defaultRate = 0.07 } = {}) {
+  constructor({ stateRegistry, role, ownerId = null, defaultRate = 0.07 } = {}) {
     super(null, 'Super Earnings');
-    this.accountKey  = accountKey;
-    this.defaultRate = defaultRate;
+    this.stateRegistry = stateRegistry;
+    this.role          = role;
+    this.ownerId       = ownerId;
+    this.defaultRate   = defaultRate;
     this.generatedActionTypes = ['SUPER_EARNINGS_APPLY', 'RECORD_METRIC', 'RECORD_BALANCE'];
   }
 
   call({ data, state }) {
-    const rate    = data?.rate ?? this.defaultRate;
-    const balance = state[this.accountKey]?.balance ?? 0;
-    const amount  = +(balance * rate).toFixed(2);
-    if (amount <= 0) return [new RecordBalanceAction(`${this.accountKey}.balance`, `${this.accountKey}`)];
+    const rate     = data?.rate ?? this.defaultRate;
+    const stateKey = this.stateRegistry.getStateKey(this.role, this.ownerId);
+    const balance  = this.stateRegistry.getAccount(state, this.role, this.ownerId)?.balance ?? 0;
+    const amount   = +(balance * rate).toFixed(2);
+    if (amount <= 0) return [new RecordBalanceAction(`${stateKey}.balance`, stateKey)];
     return [
       { type: 'SUPER_EARNINGS_APPLY', amount },
       new RecordMetricAction('super_earnings', amount),
-      new RecordBalanceAction(`${this.accountKey}.balance`, `${this.accountKey}`),
+      new RecordBalanceAction(`${stateKey}.balance`, stateKey),
     ];
   }
 }

--- a/src/finance/handlers/intl-transfer-handlers.js
+++ b/src/finance/handlers/intl-transfer-handlers.js
@@ -14,32 +14,35 @@ import { RecordBalanceAction, RecordMetricAction } from '../../simulation-framew
 /**
  * Handles user-triggered INTL_TRANSFER_TO_US events (AUD → USD).
  *
- * data.amount is the AUD amount the user wants to send from auSavingsAccount.
+ * data.amount is the AUD amount the user wants to send from the AU savings account.
  * The actual AUD withdrawn is capped to the available balance; the USD received
- * is computed after the fixed fee is subtracted. The computation is:
+ * is computed after the fixed fee is subtracted:
  *
- *   audActual     = min(data.amount, auSavingsAccount.balance)
+ *   audActual     = min(data.amount, auSavings.balance)
  *   targetDeficit = max(0, audActual / rate − fee)   [USD to land in US account]
  *
  * Emits INTL_TRANSFER_APPLY direction=AU_TO_US so IntlTransferApplyReducer
  * handles the actual ledger mutations.
  *
- * Exchange rate and fee are read from state (state.exchangeRateUsdToAud,
- * state.intlTransferFeeUsd) at event time.
- *
  * @param {object} [opts]
- * @param {string} [opts.auAccountKey='auSavingsAccount']
- * @param {string} [opts.usAccountKey='usSavingsAccount']
+ * @param {import('../services/state-registry.js').StateRegistry} opts.stateRegistry
+ * @param {string} opts.auRole      - ACCOUNT_ROLES value for the AU savings account
+ * @param {string} [opts.auOwnerId] - Person id for AU savings (null = any owner)
+ * @param {string} opts.usRole      - ACCOUNT_ROLES value for the US savings account
+ * @param {string} [opts.usOwnerId] - Person id for US savings (null = any owner)
  */
 export class IntlTransferToUsHandler extends HandlerEntry {
   static description = 'User-triggered AUD→USD transfer: converts data.amount AUD to USD using state exchange rate and fee, emitting INTL_TRANSFER_APPLY direction=AU_TO_US.';
 
   static eventType = 'INTL_TRANSFER_TO_US';
 
-  constructor({ auAccountKey = 'auSavingsAccount', usAccountKey = 'usSavingsAccount' } = {}) {
+  constructor({ stateRegistry, auRole, auOwnerId = null, usRole, usOwnerId = null } = {}) {
     super(null, 'International Transfer to US');
-    this.auAccountKey = auAccountKey;
-    this.usAccountKey = usAccountKey;
+    this.stateRegistry = stateRegistry;
+    this.auRole        = auRole;
+    this.auOwnerId     = auOwnerId;
+    this.usRole        = usRole;
+    this.usOwnerId     = usOwnerId;
     this.generatedActionTypes = ['INTL_TRANSFER_APPLY', 'RECORD_METRIC', 'RECORD_BALANCE'];
   }
 
@@ -47,12 +50,14 @@ export class IntlTransferToUsHandler extends HandlerEntry {
     const amount        = data?.amount ?? 0;
     const rate          = state.exchangeRateUsdToAud;
     const fee           = state.intlTransferFeeUsd;
-    const audActual     = Math.min(amount, state[this.auAccountKey].balance);
+    const auBalance     = this.stateRegistry.getAccount(state, this.auRole, this.auOwnerId)?.balance ?? 0;
+    const audActual     = Math.min(amount, auBalance);
     const targetDeficit = Math.max(0, audActual / rate - fee);
+    const usStateKey    = this.stateRegistry.getStateKey(this.usRole, this.usOwnerId);
     return [
       { type: 'INTL_TRANSFER_APPLY', direction: 'AU_TO_US', targetDeficit },
       new RecordMetricAction('intl_transfer_to_us', targetDeficit),
-      new RecordBalanceAction(`${this.usAccountKey}.balance`, `${this.usAccountKey}`),
+      new RecordBalanceAction(`${usStateKey}.balance`, usStateKey),
     ];
   }
 }
@@ -60,29 +65,35 @@ export class IntlTransferToUsHandler extends HandlerEntry {
 /**
  * Handles user-triggered INTL_TRANSFER_TO_AU events (USD → AUD).
  *
- * data.amount is the USD amount the user wants to send from usSavingsAccount.
+ * data.amount is the USD amount the user wants to send from the US savings account.
  * The actual USD withdrawn is capped to the available balance; the AUD received
- * is computed after the fixed fee is subtracted. The computation is:
+ * is computed after the fixed fee is subtracted:
  *
- *   usdActual     = min(data.amount, usSavingsAccount.balance)
+ *   usdActual     = min(data.amount, usSavings.balance)
  *   targetDeficit = max(0, (usdActual − fee) × rate)   [AUD to land in AU account]
  *
  * Emits INTL_TRANSFER_APPLY direction=US_TO_AU so IntlTransferApplyReducer
  * handles the actual ledger mutations.
  *
  * @param {object} [opts]
- * @param {string} [opts.usAccountKey='usSavingsAccount']
- * @param {string} [opts.auAccountKey='auSavingsAccount']
+ * @param {import('../services/state-registry.js').StateRegistry} opts.stateRegistry
+ * @param {string} opts.usRole      - ACCOUNT_ROLES value for the US savings account
+ * @param {string} [opts.usOwnerId] - Person id for US savings (null = any owner)
+ * @param {string} opts.auRole      - ACCOUNT_ROLES value for the AU savings account
+ * @param {string} [opts.auOwnerId] - Person id for AU savings (null = any owner)
  */
 export class IntlTransferToAuHandler extends HandlerEntry {
   static description = 'User-triggered USD→AUD transfer: converts data.amount USD to AUD using state exchange rate and fee, emitting INTL_TRANSFER_APPLY direction=US_TO_AU.';
 
   static eventType = 'INTL_TRANSFER_TO_AU';
 
-  constructor({ usAccountKey = 'usSavingsAccount', auAccountKey = 'auSavingsAccount' } = {}) {
+  constructor({ stateRegistry, usRole, usOwnerId = null, auRole, auOwnerId = null } = {}) {
     super(null, 'International Transfer to AU');
-    this.usAccountKey = usAccountKey;
-    this.auAccountKey = auAccountKey;
+    this.stateRegistry = stateRegistry;
+    this.usRole        = usRole;
+    this.usOwnerId     = usOwnerId;
+    this.auRole        = auRole;
+    this.auOwnerId     = auOwnerId;
     this.generatedActionTypes = ['INTL_TRANSFER_APPLY', 'RECORD_METRIC', 'RECORD_BALANCE'];
   }
 
@@ -90,12 +101,14 @@ export class IntlTransferToAuHandler extends HandlerEntry {
     const amount        = data?.amount ?? 0;
     const rate          = state.exchangeRateUsdToAud;
     const fee           = state.intlTransferFeeUsd;
-    const usdActual     = Math.min(amount, state[this.usAccountKey].balance);
+    const usBalance     = this.stateRegistry.getAccount(state, this.usRole, this.usOwnerId)?.balance ?? 0;
+    const usdActual     = Math.min(amount, usBalance);
     const targetDeficit = Math.max(0, (usdActual - fee) * rate);
+    const auStateKey    = this.stateRegistry.getStateKey(this.auRole, this.auOwnerId);
     return [
       { type: 'INTL_TRANSFER_APPLY', direction: 'US_TO_AU', targetDeficit },
       new RecordMetricAction('intl_transfer_to_au', targetDeficit),
-      new RecordBalanceAction(`${this.auAccountKey}.balance`, `${this.auAccountKey}`),
+      new RecordBalanceAction(`${auStateKey}.balance`, auStateKey),
     ];
   }
 }

--- a/src/finance/handlers/monthly-expenses-handler.js
+++ b/src/finance/handlers/monthly-expenses-handler.js
@@ -15,7 +15,8 @@ import { RecordBalanceAction, RecordMetricAction } from '../../simulation-framew
  * Handles the MONTHLY_EXPENSES event.
  *
  * Residence-aware: reads state.isAuResident to determine whether expenses
- * come from usSavingsAccount (USD pre-move) or auSavingsAccount (AUD post-move).
+ * come from the US savings account (USD pre-move) or AU savings account
+ * (AUD post-move).
  *
  * If the target savings account would fall below its minimumBalance after the
  * debit, a REPLENISH_SAVINGS action is prepended to trigger the drawdown
@@ -24,29 +25,40 @@ import { RecordBalanceAction, RecordMetricAction } from '../../simulation-framew
  * data.amount overrides the configured monthlyExpenses for one-off adjustments.
  *
  * @param {object} opts
+ * @param {import('../services/state-registry.js').StateRegistry} opts.stateRegistry
  * @param {number} [opts.monthlyExpenses=6000]
- *   Default monthly spending amount in the local currency.
- * @param {string} [opts.usAccountKey='usSavingsAccount']
- *   State key for the USD cash pool.
- * @param {string} [opts.auAccountKey='auSavingsAccount']
- *   State key for the AUD cash pool.
+ * @param {string} opts.usRole      - ACCOUNT_ROLES value for the USD cash pool
+ * @param {string} [opts.usOwnerId] - Person id for US savings (null = any owner)
+ * @param {string} opts.auRole      - ACCOUNT_ROLES value for the AUD cash pool
+ * @param {string} [opts.auOwnerId] - Person id for AU savings (null = any owner)
  */
 export class MonthlyExpensesHandler extends HandlerEntry {
-  static description = 'Residence-aware monthly expense handler: debits usSavingsAccount (pre-move) or auSavingsAccount (post-move), prepending REPLENISH_SAVINGS if the balance would fall below minimum.';
+  static description = 'Residence-aware monthly expense handler: debits US savings (pre-move) or AU savings (post-move), prepending REPLENISH_SAVINGS if the balance would fall below minimum.';
 
   static eventType = 'MONTHLY_EXPENSES';
 
-  constructor({ monthlyExpenses = 6000, usAccountKey = 'usSavingsAccount', auAccountKey = 'auSavingsAccount' } = {}) {
+  constructor({
+    stateRegistry,
+    monthlyExpenses = 6000,
+    usRole, usOwnerId = null,
+    auRole, auOwnerId = null,
+  } = {}) {
     super(null, 'Monthly Expenses');
+    this.stateRegistry  = stateRegistry;
     this.monthlyExpenses = monthlyExpenses;
-    this.usAccountKey    = usAccountKey;
-    this.auAccountKey    = auAccountKey;
+    this.usRole         = usRole;
+    this.usOwnerId      = usOwnerId;
+    this.auRole         = auRole;
+    this.auOwnerId      = auOwnerId;
     this.generatedActionTypes = ['REPLENISH_SAVINGS', 'EXPENSE_DEBIT', 'RECORD_METRIC', 'RECORD_BALANCE'];
   }
 
   call({ data, state }) {
     const amount    = data?.amount ?? state.monthlyExpenses ?? this.monthlyExpenses;
-    const targetKey = state.isAuResident ? this.auAccountKey : this.usAccountKey;
+    const isAu      = state.isAuResident;
+    const targetKey = isAu
+      ? this.stateRegistry.getStateKey(this.auRole, this.auOwnerId)
+      : this.stateRegistry.getStateKey(this.usRole, this.usOwnerId);
     const account   = state[targetKey];
 
     const actions = [];
@@ -60,7 +72,7 @@ export class MonthlyExpensesHandler extends HandlerEntry {
     actions.push(
       { type: 'EXPENSE_DEBIT', amount },
       new RecordMetricAction('monthly_expenses', amount),
-      new RecordBalanceAction(`${targetKey}.balance`, `${targetKey}`),
+      new RecordBalanceAction(`${targetKey}.balance`, targetKey),
     );
     return actions;
   }

--- a/src/finance/handlers/monthly-wages-handler.js
+++ b/src/finance/handlers/monthly-wages-handler.js
@@ -10,6 +10,7 @@
 
 import { HandlerEntry } from '../../simulation-framework/handlers.js';
 import { FieldValueAction, RecordBalanceAction } from '../../simulation-framework/actions.js';
+import { ACCOUNT_ROLES } from '../state/account-roles.js';
 
 /**
  * Handles the MONTHLY_WAGES event.
@@ -20,19 +21,23 @@ import { FieldValueAction, RecordBalanceAction } from '../../simulation-framewor
  *
  * The WagesIncomeApplyReducer (registered via the US account module) handles the
  * actual cash credit and tax chaining.
+ *
+ * @param {object} [opts]
+ * @param {import('../services/state-registry.js').StateRegistry} opts.stateRegistry
  */
 export class MonthlyWagesHandler extends HandlerEntry {
   static description = 'Credits the US cash pool with gross wages for each employed person; stops at their retirementDate.';
   static eventType   = 'MONTHLY_WAGES';
 
-  constructor() {
+  constructor({ stateRegistry } = {}) {
     super(null, 'Monthly Wages');
+    this.stateRegistry = stateRegistry;
     this.generatedActionTypes = ['WAGES_INCOME_APPLY', 'RECORD_FIELD_VALUE', 'RECORD_BALANCE'];
   }
 
   call({ date, state }) {
     const actions = [];
-    const cashKey = state.usSavingsAccount != null ? 'usSavingsAccount' : 'checkingAccount';
+    const cashKey = this.stateRegistry?.getStateKey(ACCOUNT_ROLES.US_SAVINGS) ?? 'usSavingsAccount';
 
     for (const [key, person] of Object.entries(state.people ?? {})) {
       const wage = person.monthlyWage ?? 0;

--- a/src/finance/handlers/us-savings-interest-handler.js
+++ b/src/finance/handlers/us-savings-interest-handler.js
@@ -19,31 +19,34 @@ import { RecordBalanceAction, RecordMetricAction } from '../../simulation-framew
  * update YTD accumulators (including AU cross-reporting when resident).
  *
  * @param {object} opts
- * @param {string} [opts.accountKey='usSavingsAccount']
- *   State key for the savings account whose balance drives the calculation.
- * @param {number} [opts.interestRate=0.03]
- *   Annual interest rate (e.g. 0.03 = 3%).
+ * @param {import('../services/state-registry.js').StateRegistry} opts.stateRegistry
+ * @param {string} opts.role       - ACCOUNT_ROLES value for the savings account
+ * @param {string} [opts.ownerId]  - Person id (null = any owner)
+ * @param {number} [opts.interestRate=0.03] Annual interest rate (e.g. 0.03 = 3%)
  */
 export class UsSavingsInterestMonthlyHandler extends HandlerEntry {
   static description = 'Computes monthly interest on a US savings account and emits US_SAVINGS_INTEREST_CREDIT.';
 
   static eventType = 'US_SAVINGS_INTEREST_MONTHLY';
 
-  constructor({ accountKey = 'usSavingsAccount', interestRate = 0.03 } = {}) {
+  constructor({ stateRegistry, role, ownerId = null, interestRate = 0.03 } = {}) {
     super(null, 'Monthly US Savings Interest');
-    this.accountKey   = accountKey;
-    this.interestRate = interestRate;
+    this.stateRegistry = stateRegistry;
+    this.role          = role;
+    this.ownerId       = ownerId;
+    this.interestRate  = interestRate;
     this.generatedActionTypes = ['US_SAVINGS_INTEREST_CREDIT', 'RECORD_METRIC', 'RECORD_BALANCE'];
   }
 
   call({ state }) {
-    const balance = state[this.accountKey]?.balance ?? 0;
-    const amount  = +(balance * this.interestRate / 12).toFixed(2);
-    if (amount <= 0) return [new RecordBalanceAction(`${this.accountKey}.balance`, `${this.accountKey}`)];
+    const stateKey = this.stateRegistry.getStateKey(this.role, this.ownerId);
+    const balance  = this.stateRegistry.getAccount(state, this.role, this.ownerId)?.balance ?? 0;
+    const amount   = +(balance * this.interestRate / 12).toFixed(2);
+    if (amount <= 0) return [new RecordBalanceAction(`${stateKey}.balance`, stateKey)];
     return [
       { type: 'US_SAVINGS_INTEREST_CREDIT', amount },
       new RecordMetricAction('us_savings_interest', amount),
-      new RecordBalanceAction(`${this.accountKey}.balance`, `${this.accountKey}`),
+      new RecordBalanceAction(`${stateKey}.balance`, stateKey),
     ];
   }
 }

--- a/src/finance/reducers/change-residency-apply-reducer.js
+++ b/src/finance/reducers/change-residency-apply-reducer.js
@@ -29,32 +29,24 @@ import { Reducer, PRIORITY } from '../../simulation-framework/reducers.js';
  *
  * @param {object} opts
  * @param {import('../../finance/services/account-service.js').AccountService} opts.accountService
- * @param {string[]} [opts.investmentKeys]
- *   State keys of InvestmentAccount instances that should have their
- *   balanceAtResidencyChange snapshotted. Defaults to the standard set used
- *   in the international retirement scenario.
+ * @param {import('../../finance/services/state-registry.js').StateRegistry} opts.stateRegistry
  */
 export class ChangeResidencyApplyReducer extends Reducer {
   static description = 'Flips isAuResident, snapshots investment account balances at residency change, and adds AU citizenship to all people in state.';
 
   static actionType = 'CHANGE_RESIDENCY_APPLY';
 
-  static DEFAULT_INVESTMENT_KEYS = [
-    'rothAccount', 'iraAccount', 'k401Account',
-    'usStockAccount', 'superAccount', 'auStockAccount',
-  ];
-
-  constructor({ accountService, investmentKeys = ChangeResidencyApplyReducer.DEFAULT_INVESTMENT_KEYS } = {}) {
+  constructor({ accountService, stateRegistry } = {}) {
     super('Change Residency Apply', PRIORITY.PRE_PROCESS);
     this.accountService  = accountService;
-    this.investmentKeys  = investmentKeys;
+    this.stateRegistry   = stateRegistry;
     this.reducedActionTypes = ['CHANGE_RESIDENCY_APPLY'];
   }
 
   reduce(state) {
-    // 1. Snapshot balanceAtResidencyChange on investment accounts
-    for (const key of this.investmentKeys) {
-      if (state[key]) this.accountService.recordResidencyChange(state[key]);
+    // 1. Snapshot balanceAtResidencyChange on all registered accounts
+    for (const account of this.stateRegistry.getAccounts(state)) {
+      this.accountService.recordResidencyChange(account);
     }
 
     // 2. Add AU citizenship to every person in state.people

--- a/src/finance/reducers/change-residency-apply-reducer.js
+++ b/src/finance/reducers/change-residency-apply-reducer.js
@@ -41,7 +41,7 @@ export class ChangeResidencyApplyReducer extends Reducer {
 
   static DEFAULT_INVESTMENT_KEYS = [
     'rothAccount', 'iraAccount', 'k401Account',
-    'stockAccount', 'superAccount', 'auStockAccount',
+    'usStockAccount', 'superAccount', 'auStockAccount',
   ];
 
   constructor({ accountService, investmentKeys = ChangeResidencyApplyReducer.DEFAULT_INVESTMENT_KEYS } = {}) {

--- a/src/finance/reducers/replenish-savings-reducer.js
+++ b/src/finance/reducers/replenish-savings-reducer.js
@@ -48,7 +48,7 @@ export class ReplenishSavingsReducer extends Reducer {
 
   reduce(state, action, date) {
     const { deficit, targetKey } = action;
-    const isAu = targetKey === 'auSavingsAccount';
+    const isAu = state[targetKey]?.country === 'AU';
 
     try {
       const { drawnKeys, pendingTaxActions } = this.accountService.replenishSavings(

--- a/src/finance/reducers/stock-dividend-cash-apply-reducer.js
+++ b/src/finance/reducers/stock-dividend-cash-apply-reducer.js
@@ -9,11 +9,12 @@
  */
 
 import { Reducer, PRIORITY } from '../../simulation-framework/reducers.js';
+import { ACCOUNT_ROLES } from '../state/account-roles.js';
 
 /**
  * Handles STOCK_DIVIDEND_CASH_APPLY actions (cash payout path).
  *
- * Credits the dividend amount to the named savings account via AccountService,
+ * Credits the dividend amount to the US savings account (resolved via StateRegistry),
  * then chains STOCK_DIVIDEND_TAX { amount, isAuResident } so the tax module
  * can classify it as US ordinary income (and AU ordinary income when resident).
  *
@@ -23,25 +24,29 @@ import { Reducer, PRIORITY } from '../../simulation-framework/reducers.js';
  *
  * @param {object} opts
  * @param {import('../../finance/services/account-service.js').AccountService} opts.accountService
- * @param {string} [opts.accountKey='usSavingsAccount']
- *   State key for the savings account to credit with the cash dividend.
+ * @param {import('../services/state-registry.js').StateRegistry} opts.stateRegistry
+ * @param {string} [opts.role=ACCOUNT_ROLES.US_SAVINGS]
+ * @param {string|null} [opts.ownerId=null]
  */
 export class StockDividendCashApplyReducer extends Reducer {
   static description = 'Credits stock dividend cash payout to the savings account and chains STOCK_DIVIDEND_TAX for tax classification.';
 
   static actionType = 'STOCK_DIVIDEND_CASH_APPLY';
 
-  constructor({ accountService, accountKey = 'usSavingsAccount' } = {}) {
+  constructor({ accountService, stateRegistry, role = ACCOUNT_ROLES.US_SAVINGS, ownerId = null } = {}) {
     super('Stock Dividend Cash Apply', PRIORITY.CASH_FLOW);
-    this.accountService = accountService;
-    this.accountKey     = accountKey;
+    this.accountService  = accountService;
+    this.stateRegistry   = stateRegistry;
+    this.role            = role;
+    this.ownerId         = ownerId;
     this.reducedActionTypes  = ['STOCK_DIVIDEND_CASH_APPLY'];
     this.generatedActionTypes = ['STOCK_DIVIDEND_TAX'];
   }
 
   reduce(state, action, date) {
     const { amount, isAuResident } = action;
-    this.accountService.transaction(state[this.accountKey], amount, date);
+    const key = this.stateRegistry.getStateKey(this.role, this.ownerId);
+    this.accountService.transaction(state[key], amount, date);
     return this.newState(state, {}, [{ type: 'STOCK_DIVIDEND_TAX', amount, isAuResident }]);
   }
 }

--- a/src/finance/reducers/us-savings-interest-credit-reducer.js
+++ b/src/finance/reducers/us-savings-interest-credit-reducer.js
@@ -9,38 +9,39 @@
  */
 
 import { Reducer, PRIORITY } from '../../simulation-framework/reducers.js';
+import { ACCOUNT_ROLES } from '../state/account-roles.js';
 
 /**
  * Handles the US_SAVINGS_INTEREST_CREDIT action.
  *
- * Credits action.amount to the named US savings account via AccountService,
+ * Credits action.amount to the US savings account (resolved via StateRegistry)
  * then increments usOrdinaryIncomeYTD. When the person is already an AU
  * resident, the same amount is also added to auOrdinaryIncomeYTD and ftcYTD
  * (foreign-tax-credit tracking for cross-country tax reconciliation).
  *
- * AccountService is injected at construction time so this class holds no
- * non-serializable state of its own; only accountKey is persisted.
- *
  * @param {object} opts
  * @param {import('../../finance/services/account-service.js').AccountService} opts.accountService
- * @param {string} [opts.accountKey='usSavingsAccount']
- *   State key for the savings account to credit.
+ * @param {import('../services/state-registry.js').StateRegistry} opts.stateRegistry
+ * @param {string} [opts.role=ACCOUNT_ROLES.US_SAVINGS]
+ * @param {string|null} [opts.ownerId=null]
  */
 export class UsSavingsInterestCreditReducer extends Reducer {
   static description = 'Credits interest to a US savings account and increments usOrdinaryIncomeYTD (plus auOrdinaryIncomeYTD/ftcYTD when AU-resident).';
 
-  /** Action type this reducer handles. Used by SimulationSync for auto-wiring. */
   static actionType = 'US_SAVINGS_INTEREST_CREDIT';
 
-  constructor({ accountService, accountKey = 'usSavingsAccount' } = {}) {
+  constructor({ accountService, stateRegistry, role = ACCOUNT_ROLES.US_SAVINGS, ownerId = null } = {}) {
     super('US Savings Interest Credit', PRIORITY.CASH_FLOW);
     this.accountService = accountService;
-    this.accountKey     = accountKey;
+    this.stateRegistry  = stateRegistry;
+    this.role           = role;
+    this.ownerId        = ownerId;
     this.reducedActionTypes = ['US_SAVINGS_INTEREST_CREDIT'];
   }
 
   reduce(state, action, date) {
-    this.accountService.transaction(state[this.accountKey], action.amount, date);
+    const key = this.stateRegistry.getStateKey(this.role, this.ownerId);
+    this.accountService.transaction(state[key], action.amount, date);
 
     const usNext = (state.usOrdinaryIncomeYTD ?? 0) + action.amount;
     const base   = { ...state, usOrdinaryIncomeYTD: usNext };

--- a/src/finance/services/state-registry.js
+++ b/src/finance/services/state-registry.js
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Terry Packer.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * StateRegistry — query facade for resolving simulation state objects by
+ * semantic role rather than hard-coded state key strings.
+ *
+ * Holds a reference to AccountService (populated at scenario build time).
+ * Every registered account has a `stateKey` stamped by SimulationState
+ * `_assignAccount`, so lookups bridge the service registry to the live state.
+ *
+ * Usage:
+ *   const account = stateRegistry.getAccount(state, ACCOUNT_ROLES.ROTH, primary.id);
+ *   const auAccounts = stateRegistry.getAccounts(state, { country: 'AU' });
+ *
+ * Designed for extension: future methods can cover people, assets, etc.
+ */
+export class StateRegistry {
+  /**
+   * @param {object} opts
+   * @param {import('./account-service.js').AccountService} opts.accountService
+   */
+  constructor({ accountService }) {
+    this._accountService = accountService;
+  }
+
+  /**
+   * Returns the live state object for the first account matching role + ownerId.
+   *
+   * @param {object}      state   - Current simulation state
+   * @param {string}      role    - ACCOUNT_ROLES value (e.g. 'roth-ira')
+   * @param {string|null} [ownerId=null] - Person id; null matches any owner
+   * @returns {object|null}
+   */
+  getAccount(state, role, ownerId = null) {
+    for (const account of this._accountService.getAll()) {
+      if (account.role !== role) continue;
+      if (ownerId !== null && account.ownerId !== ownerId) continue;
+      return state[account.stateKey] ?? null;
+    }
+    return null;
+  }
+
+  /**
+   * Returns all live state account objects matching all provided filters.
+   * Omit a filter key to match all values for that field.
+   *
+   * @param {object} state
+   * @param {object} [filters]
+   * @param {string} [filters.role]        - ACCOUNT_ROLES value
+   * @param {string} [filters.ownerId]     - Person id
+   * @param {string} [filters.country]     - ISO country code ('US', 'AU')
+   * @param {string} [filters.accountType] - ACCOUNT_TYPE value
+   * @returns {object[]}
+   */
+  getAccounts(state, { role, ownerId, country, accountType } = {}) {
+    const results = [];
+    for (const account of this._accountService.getAll()) {
+      if (role        !== undefined && account.role    !== role)        continue;
+      if (ownerId     !== undefined && account.ownerId !== ownerId)     continue;
+      if (country     !== undefined && account.country !== country)     continue;
+      if (accountType !== undefined && account.type    !== accountType) continue;
+      const stateAccount = state[account.stateKey];
+      if (stateAccount != null) results.push(stateAccount);
+    }
+    return results;
+  }
+}

--- a/src/finance/services/state-registry.js
+++ b/src/finance/services/state-registry.js
@@ -49,6 +49,23 @@ export class StateRegistry {
   }
 
   /**
+   * Returns the stateKey for the first account matching role + ownerId.
+   * Useful for building RecordBalanceAction paths without holding a state reference.
+   *
+   * @param {string}      role    - ACCOUNT_ROLES value
+   * @param {string|null} [ownerId=null] - Person id; null matches any owner
+   * @returns {string|null}
+   */
+  getStateKey(role, ownerId = null) {
+    for (const account of this._accountService.getAll()) {
+      if (account.role !== role) continue;
+      if (ownerId !== null && account.ownerId !== ownerId) continue;
+      return account.stateKey ?? null;
+    }
+    return null;
+  }
+
+  /**
    * Returns all live state account objects matching all provided filters.
    * Omit a filter key to match all values for that field.
    *

--- a/src/finance/state/account-roles.js
+++ b/src/finance/state/account-roles.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 Terry Packer.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * Semantic role identifiers for all accounts in the simulation state.
+ *
+ * A role describes what an account *is* (its function), independent of its
+ * state property name or who owns it.  Handlers and reducers use role +
+ * ownerId to look up accounts via StateRegistry rather than hard-coding
+ * state key strings.
+ *
+ * Naming convention: kebab-case strings that read as account descriptions.
+ */
+export const ACCOUNT_ROLES = Object.freeze({
+  US_SAVINGS:   'us-savings',
+  FIXED_INCOME: 'fixed-income',
+  US_STOCK:     'us-stock',
+  IRA:          'ira',
+  K401:         'k401',
+  ROTH:         'roth-ira',
+  AU_SAVINGS:   'au-savings',
+  AU_STOCK:     'au-stock',
+  SUPER:        'super',
+});

--- a/src/finance/state/intl-retirement-state.js
+++ b/src/finance/state/intl-retirement-state.js
@@ -27,6 +27,8 @@ export class InternationalRetirementFinancialState extends SimulationState {
     usSavingsAccount, fixedIncomeAccount, usStockAccount,
     iraAccount, k401Account, rothAccount,
     auSavingsAccount, auStockAccount, superAccount,
+      // Spouse retirement accounts
+    spouseRothAccount, spouseIraAccount, spouseK401Account, spouseSuperAccount,
     exchangeRateUsdToAud,
     intlTransferFeeUsd,
     inflationRates,
@@ -52,6 +54,12 @@ export class InternationalRetirementFinancialState extends SimulationState {
     this._assignAccount('auSavingsAccount', auSavingsAccount);
     this._assignAccount('auStockAccount', auStockAccount);
     this._assignAccount('superAccount', superAccount);
+
+    // Spouse retirement accounts
+    this._assignAccount('spouseRothAccount', spouseRothAccount);
+    this._assignAccount('spouseIraAccount', spouseIraAccount);
+    this._assignAccount('spouseK401Account', spouseK401Account);
+    this._assignAccount('spouseSuperAccount', spouseSuperAccount);
 
     //TODO Move to FX When available.
     this.exchangeRateUsdToAud = exchangeRateUsdToAud;

--- a/src/finance/state/intl-retirement-state.js
+++ b/src/finance/state/intl-retirement-state.js
@@ -24,7 +24,7 @@ export class InternationalRetirementFinancialState extends SimulationState {
       //People
     primary, spouse,
       //Accounts
-    usSavingsAccount, fixedIncomeAccount, stockAccount,
+    usSavingsAccount, fixedIncomeAccount, usStockAccount,
     iraAccount, k401Account, rothAccount,
     auSavingsAccount, auStockAccount, superAccount,
     exchangeRateUsdToAud,
@@ -43,7 +43,7 @@ export class InternationalRetirementFinancialState extends SimulationState {
     //US Accounts
     this._assignAccount('usSavingsAccount', usSavingsAccount);
     this._assignAccount('fixedIncomeAccount', fixedIncomeAccount);
-    this._assignAccount('stockAccount', stockAccount);
+    this._assignAccount('usStockAccount', usStockAccount);
     this._assignAccount('iraAccount', iraAccount);
     this._assignAccount('k401Account', k401Account);
     this._assignAccount('rothAccount', rothAccount);

--- a/src/finance/tax-service.js
+++ b/src/finance/tax-service.js
@@ -161,7 +161,7 @@ export class TaxService {
    * @param {string[]} countryCodes
    */
   registerHandlersAndReducers(serviceRegistry, countryCodes) {
-    const { reducerService, handlerService, accountService, eventService } = serviceRegistry;
+    const { reducerService, handlerService, accountService, eventService, stateRegistry } = serviceRegistry;
 
     const periodAdvanceHandler = new PeriodAdvanceHandler();
 
@@ -228,7 +228,7 @@ export class TaxService {
     // TAX_SETTLE handler + reducers
     handlerService.register(taxSettleHandler);
     reducerService.register(new TaxSettleApplyReducer());
-    reducerService.register(new TaxPaymentDebitReducer({ accountService }));
+    reducerService.register(new TaxPaymentDebitReducer({ accountService, stateRegistry }));
 
     // Metric/balance reducers
     const taxDebitReducer = new ArrayReducer('Tax Debit');

--- a/src/finance/tax/au/au-tax-module-2026.js
+++ b/src/finance/tax/au/au-tax-module-2026.js
@@ -93,11 +93,13 @@ export class AuTaxModule2026 extends BaseTaxModule {
       // EVT-23: super earnings — AU super tax at 15%, no US tax
       ['SUPER_EARNINGS_TAX', (state, action) => {
         const superTax = action.amount * SUPER_TAX_RATE;
-        const perPerson = state.people != null && state.superAccount != null;
+        const accountKey = action.stateKey ?? 'superAccount';
+        const account = state[accountKey];
+        const perPerson = state.people != null && account != null;
         return {
           ...state,
           ...(perPerson
-            ? { auPersonSuperTaxYTD: accumulateByOwnership(state.auPersonSuperTaxYTD ?? {}, state.superAccount, superTax, state.people) }
+            ? { auPersonSuperTaxYTD: accumulateByOwnership(state.auPersonSuperTaxYTD ?? {}, account, superTax, state.people) }
             : { auSuperTaxYTD: state.auSuperTaxYTD + superTax }),
         };
       }],

--- a/src/finance/tax/tax-settle-classes.js
+++ b/src/finance/tax/tax-settle-classes.js
@@ -12,6 +12,7 @@ import { Reducer, PRIORITY }  from '../../simulation-framework/reducers.js';
 import { HandlerEntry }        from '../../simulation-framework/handlers.js';
 import { TaxSettleService }    from '../tax-settle-service.js';
 import { InsufficientFundsError } from '../assets/account.js';
+import { ACCOUNT_ROLES } from '../state/account-roles.js';
 
 // YTD fields reset to zero after each annual settlement, keyed by country code.
 const YTD_FIELDS = {
@@ -127,15 +128,17 @@ export class TaxPaymentDebitReducer extends Reducer {
   static description = 'Debits the country savings account for the tax amount; replenishes from investment accounts first when the balance is short.';
   static actionType  = 'TAX_PAYMENT_DEBIT';
 
-  constructor({ accountService }) {
+  constructor({ accountService, stateRegistry }) {
     super('Tax Payment Debit', PRIORITY.TAX_APPLY + 1);
     this.accountService = accountService;
+    this.stateRegistry  = stateRegistry;
     this.reducedActionTypes = ['TAX_PAYMENT_DEBIT'];
   }
 
   reduce(state, action, date) {
     const { amount, cc } = action;
-    const accountKey  = cc === 'AU' ? 'auSavingsAccount' : 'usSavingsAccount';
+    const role       = cc === 'AU' ? ACCOUNT_ROLES.AU_SAVINGS : ACCOUNT_ROLES.US_SAVINGS;
+    const accountKey = this.stateRegistry.getStateKey(role);
     const cashAccount = state[accountKey];
     const shortfall   = amount - Math.max(0, cashAccount.balance);
 

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,8 @@ import { AssetService } from './finance/services/asset-service.js';
 import { CollectibleService } from './finance/services/collectible-service.js';
 import { PersonService } from './finance/services/person-service.js';
 import { RealPropertyService } from './finance/services/real-property-service.js';
+import { StateRegistry } from './finance/services/state-registry.js';
+import { ACCOUNT_ROLES } from './finance/state/account-roles.js';
 import { FinancialState } from './finance/state/financial-state.js';
 import { InternationalRetirementFinancialState } from './finance/state/intl-retirement-state.js';
 import { AuTaxDocument2024 } from './finance/tax/au/au-tax-document-2024.js';
@@ -367,6 +369,8 @@ export const Finance = {
   CollectibleService,
   PersonService,
   RealPropertyService,
+  StateRegistry,
+  ACCOUNT_ROLES,
   FinancialState,
   InternationalRetirementFinancialState,
   AuTaxDocument2024,

--- a/src/scenarios/intl-retirement-scenario.js
+++ b/src/scenarios/intl-retirement-scenario.js
@@ -43,6 +43,7 @@ import {
 import {
   InternationalRetirementFinancialState
 } from "../finance/state/intl-retirement-state.js";
+import { ACCOUNT_ROLES } from '../finance/state/account-roles.js';
 
 /**
  * Default parameters for the International Retirement scenario.
@@ -386,20 +387,24 @@ export class IntlRetirementScenario extends BaseScenario {
     // ── US accounts ───────────────────────────────────────────────────────────
     const usSavingsAccount = new Account(p.initialUsSavings, {
       name:          'US Savings',
+      role:          ACCOUNT_ROLES.US_SAVINGS,
       ownershipType: 'joint',
+      ownerId:       primary.id,
       minimumBalance: p.usSavingsMinBalance,
       country:       'US',
       currency:      USD,
     });
     const fixedIncomeAccount = new Account(p.fixedIncomeBalance, {
       name:             'Fixed Income',
+      role:             ACCOUNT_ROLES.FIXED_INCOME,
       country:          'US',
       currency:         USD,
       ownerId:          primary.id,
       drawdownPriority: 1,
     });
-    const stockAccount = new InvestmentAccount(p.stockBalance, {
+    const usStockAccount = new InvestmentAccount(p.stockBalance, {
       name:             'US Stock',
+      role:             ACCOUNT_ROLES.US_STOCK,
       contributionBasis: p.stockBasis,
       country:          'US',
       currency:         USD,
@@ -408,6 +413,7 @@ export class IntlRetirementScenario extends BaseScenario {
     });
     const iraAccount = new TraditionalIRAAccount(p.iraBalance, {
       name:             'Traditional IRA',
+      role:             ACCOUNT_ROLES.IRA,
       contributionBasis: p.iraBasis,
       country:          'US',
       currency:         USD,
@@ -416,6 +422,7 @@ export class IntlRetirementScenario extends BaseScenario {
     });
     const k401Account = new FourOhOneKAccount(p.k401Balance, {
       name:             '401(k)',
+      role:             ACCOUNT_ROLES.K401,
       contributionBasis: p.k401Basis,
       country:          'US',
       currency:         USD,
@@ -424,6 +431,7 @@ export class IntlRetirementScenario extends BaseScenario {
     });
     const rothAccount = new RothAccount(p.rothBalance, {
       name:             'Roth IRA',
+      role:             ACCOUNT_ROLES.ROTH,
       contributionBasis: p.rothBasis,
       country:          'US',
       currency:         USD,
@@ -433,13 +441,17 @@ export class IntlRetirementScenario extends BaseScenario {
 
     // ── AU accounts ───────────────────────────────────────────────────────────
     const auSavingsAccount = new Account(p.auSavingsBalance, {
-      name:     'AU Savings',
-      country:  'AU',
+      name:          'AU Savings',
+      role:          ACCOUNT_ROLES.AU_SAVINGS,
+      ownershipType: 'joint',
+      ownerId:       primary.id,
+      country:       'AU',
       minimumBalance: p.auSavingsMinBalance,
-      currency: AUD,
+      currency:      AUD,
     });
     const auStockAccount = new InvestmentAccount(p.auStockBalance, {
       name:             'AU Stock',
+      role:             ACCOUNT_ROLES.AU_STOCK,
       contributionBasis: p.auStockBasis,
       country:          'AU',
       currency:         AUD,
@@ -448,6 +460,7 @@ export class IntlRetirementScenario extends BaseScenario {
     });
     const superAccount = new InvestmentAccount(p.superBalance, {
       name:             'Superannuation',
+      role:             ACCOUNT_ROLES.SUPER,
       contributionBasis: p.superBasis,
       country:          'AU',
       currency:         AUD,
@@ -459,14 +472,14 @@ export class IntlRetirementScenario extends BaseScenario {
     // ── Store for loadDefaults() ──────────────────────────────────────────────
     this._people = { primary, spouse };
     this._accounts = {
-      usSavingsAccount, fixedIncomeAccount, stockAccount,
+      usSavingsAccount, fixedIncomeAccount, usStockAccount,
       iraAccount, k401Account, rothAccount,
       auSavingsAccount, auStockAccount, superAccount,
     };
 
     return new InternationalRetirementFinancialState({
       primary, spouse,
-      usSavingsAccount, fixedIncomeAccount, stockAccount,
+      usSavingsAccount, fixedIncomeAccount, usStockAccount,
       iraAccount, k401Account, rothAccount,
       auSavingsAccount, auStockAccount, superAccount,
       exchangeRateUsdToAud: p.exchangeRateUsdToAud,

--- a/src/scenarios/intl-retirement-scenario.js
+++ b/src/scenarios/intl-retirement-scenario.js
@@ -80,6 +80,14 @@ export const INTL_RETIREMENT_DEFAULTS = {
   k401GrowthRate:   0.07,
   usStockGrowthRate: 0.05,
 
+  // Spouse retirement accounts (US)
+  spouseRothBalance:  40_000,  spouseRothBasis:  30_000,  spouseRothGrowthRate:  0.07,
+  spouseIraBalance:  100_000,  spouseIraBasis:   75_000,  spouseIraGrowthRate:   0.07,
+  spouseK401Balance: 150_000,  spouseK401Basis: 100_000,  spouseK401GrowthRate:  0.07,
+
+  // Spouse retirement account (AU)
+  spouseSuperBalance: 125_000,  spouseSuperBasis: 90_000,  spouseSuperGrowthRate: 0.07,
+
   // AU accounts
   auSavingsBalance:     50_000,
   auSavingsMinBalance:   3_000,  auSavingsInterestRate: 0.045,
@@ -207,6 +215,58 @@ export const INTL_RETIREMENT_PARAM_SCHEMA = [
     type: 'Number', group: 'AU Account Balances',
     defaultValue: INTL_RETIREMENT_DEFAULTS.auStockBalance,
     description: 'Starting AU brokerage stock balance (MC)',
+  },
+
+  // ── Spouse Account Balances ────────────────────────────────────────────────
+  {
+    key: 'spouseRothBalance', label: 'Spouse Roth IRA Balance (USD)',
+    type: 'Number', group: 'Spouse Account Balances',
+    defaultValue: INTL_RETIREMENT_DEFAULTS.spouseRothBalance,
+    description: 'Starting Roth IRA balance for spouse (MC)',
+  },
+  {
+    key: 'spouseIraBalance', label: 'Spouse Traditional IRA Balance (USD)',
+    type: 'Number', group: 'Spouse Account Balances',
+    defaultValue: INTL_RETIREMENT_DEFAULTS.spouseIraBalance,
+    description: 'Starting Traditional IRA balance for spouse (MC)',
+  },
+  {
+    key: 'spouseK401Balance', label: 'Spouse 401(k) Balance (USD)',
+    type: 'Number', group: 'Spouse Account Balances',
+    defaultValue: INTL_RETIREMENT_DEFAULTS.spouseK401Balance,
+    description: 'Starting 401(k) balance for spouse (MC)',
+  },
+  {
+    key: 'spouseSuperBalance', label: 'Spouse Superannuation Balance (AUD)',
+    type: 'Number', group: 'Spouse Account Balances',
+    defaultValue: INTL_RETIREMENT_DEFAULTS.spouseSuperBalance,
+    description: 'Starting superannuation balance for spouse (MC)',
+  },
+
+  // ── Spouse Account Rates ───────────────────────────────────────────────────
+  {
+    key: 'spouseRothGrowthRate', label: 'Spouse Roth IRA Growth Rate',
+    type: 'Number', group: 'Spouse Account Rates',
+    defaultValue: INTL_RETIREMENT_DEFAULTS.spouseRothGrowthRate,
+    description: 'Annual growth rate for spouse Roth IRA (MC)',
+  },
+  {
+    key: 'spouseIraGrowthRate', label: 'Spouse Traditional IRA Growth Rate',
+    type: 'Number', group: 'Spouse Account Rates',
+    defaultValue: INTL_RETIREMENT_DEFAULTS.spouseIraGrowthRate,
+    description: 'Annual growth rate for spouse Traditional IRA (MC)',
+  },
+  {
+    key: 'spouseK401GrowthRate', label: 'Spouse 401(k) Growth Rate',
+    type: 'Number', group: 'Spouse Account Rates',
+    defaultValue: INTL_RETIREMENT_DEFAULTS.spouseK401GrowthRate,
+    description: 'Annual growth rate for spouse 401(k) (MC)',
+  },
+  {
+    key: 'spouseSuperGrowthRate', label: 'Spouse Super Growth Rate',
+    type: 'Number', group: 'Spouse Account Rates',
+    defaultValue: INTL_RETIREMENT_DEFAULTS.spouseSuperGrowthRate,
+    description: 'Annual growth rate for spouse superannuation (MC)',
   },
 
   // ── US Account Rates ───────────────────────────────────────────────────────
@@ -469,12 +529,52 @@ export class IntlRetirementScenario extends BaseScenario {
       minimumAge:       60,
     });
 
+    // ── Spouse retirement accounts ─────────────────────────────────────────────
+    const spouseRothAccount = new RothAccount(p.spouseRothBalance, {
+      name:             'Roth IRA (Spouse)',
+      role:             ACCOUNT_ROLES.ROTH,
+      contributionBasis: p.spouseRothBasis,
+      country:          'US',
+      currency:         USD,
+      ownerId:          spouse.id,
+      drawdownPriority: 8,
+    });
+    const spouseIraAccount = new TraditionalIRAAccount(p.spouseIraBalance, {
+      name:             'Traditional IRA (Spouse)',
+      role:             ACCOUNT_ROLES.IRA,
+      contributionBasis: p.spouseIraBasis,
+      country:          'US',
+      currency:         USD,
+      ownerId:          spouse.id,
+      drawdownPriority: 6,
+    });
+    const spouseK401Account = new FourOhOneKAccount(p.spouseK401Balance, {
+      name:             '401(k) (Spouse)',
+      role:             ACCOUNT_ROLES.K401,
+      contributionBasis: p.spouseK401Basis,
+      country:          'US',
+      currency:         USD,
+      ownerId:          spouse.id,
+      drawdownPriority: 7,
+    });
+    const spouseSuperAccount = new InvestmentAccount(p.spouseSuperBalance, {
+      name:             'Superannuation (Spouse)',
+      role:             ACCOUNT_ROLES.SUPER,
+      contributionBasis: p.spouseSuperBasis,
+      country:          'AU',
+      currency:         AUD,
+      ownerId:          spouse.id,
+      drawdownPriority: 3,
+      minimumAge:       60,
+    });
+
     // ── Store for loadDefaults() ──────────────────────────────────────────────
     this._people = { primary, spouse };
     this._accounts = {
       usSavingsAccount, fixedIncomeAccount, usStockAccount,
       iraAccount, k401Account, rothAccount,
       auSavingsAccount, auStockAccount, superAccount,
+      spouseRothAccount, spouseIraAccount, spouseK401Account, spouseSuperAccount,
     };
 
     return new InternationalRetirementFinancialState({
@@ -482,6 +582,7 @@ export class IntlRetirementScenario extends BaseScenario {
       usSavingsAccount, fixedIncomeAccount, usStockAccount,
       iraAccount, k401Account, rothAccount,
       auSavingsAccount, auStockAccount, superAccount,
+      spouseRothAccount, spouseIraAccount, spouseK401Account, spouseSuperAccount,
       exchangeRateUsdToAud: p.exchangeRateUsdToAud,
       intlTransferFeeUsd:   p.intlTransferFeeUsd,
       inflationRates:       { US: p.usInflationRate, AU: p.auInflationRate },
@@ -528,6 +629,7 @@ export class IntlRetirementScenario extends BaseScenario {
     const { eventService, handlerService, reducerService, accountService, personService, stateRegistry } = ServiceRegistry.getInstance();
     const p = this._params;
     const primaryId = this._people.primary.id;
+    const spouseId  = this._people.spouse.id;
 
     // ── TaxService phase 2: register handlers/reducers through the service layer
     this._taxService.registerHandlersAndReducers(ServiceRegistry.getInstance(), ['US', 'AU']);
@@ -703,6 +805,43 @@ export class IntlRetirementScenario extends BaseScenario {
     });
     k401EarningsHandler.handledEvents.push(k401EarningsEvent);
     handlerService.register(k401EarningsHandler);
+
+    // ── Spouse retirement account handlers ────────────────────────────────────
+    const spouseSuperHandler = new SuperEarningsHandler({
+      stateRegistry,
+      role:        ACCOUNT_ROLES.SUPER,
+      ownerId:     spouseId,
+      defaultRate: p.spouseSuperGrowthRate,
+    });
+    spouseSuperHandler.handledEvents.push(superEvent);
+    handlerService.register(spouseSuperHandler);
+
+    const spouseRothEarningsHandler = new IntlRothEarningsHandler({
+      stateRegistry,
+      role:       ACCOUNT_ROLES.ROTH,
+      ownerId:    spouseId,
+      growthRate: p.spouseRothGrowthRate,
+    });
+    spouseRothEarningsHandler.handledEvents.push(rothEarningsEvent);
+    handlerService.register(spouseRothEarningsHandler);
+
+    const spouseIraEarningsHandler = new IntlIraEarningsHandler({
+      stateRegistry,
+      role:       ACCOUNT_ROLES.IRA,
+      ownerId:    spouseId,
+      growthRate: p.spouseIraGrowthRate,
+    });
+    spouseIraEarningsHandler.handledEvents.push(iraEarningsEvent);
+    handlerService.register(spouseIraEarningsHandler);
+
+    const spouseK401EarningsHandler = new IntlK401EarningsHandler({
+      stateRegistry,
+      role:       ACCOUNT_ROLES.K401,
+      ownerId:    spouseId,
+      growthRate: p.spouseK401GrowthRate,
+    });
+    spouseK401EarningsHandler.handledEvents.push(k401EarningsEvent);
+    handlerService.register(spouseK401EarningsHandler);
 
     const usStockEarningsHandler = new IntlUsStockEarningsHandler({
       stateRegistry,

--- a/src/scenarios/intl-retirement-scenario.js
+++ b/src/scenarios/intl-retirement-scenario.js
@@ -909,10 +909,20 @@ export class IntlRetirementScenario extends BaseScenario {
     const intlTransferReducer = new IntlTransferApplyReducer({ accountService: svc });
     reducerService.register(intlTransferReducer);
 
-    const usSavingsIntCreditReducer = new UsSavingsInterestCreditReducer({ accountService: svc });
+    const usSavingsIntCreditReducer = new UsSavingsInterestCreditReducer({
+      accountService: svc,
+      stateRegistry,
+      role:    ACCOUNT_ROLES.US_SAVINGS,
+      ownerId: primaryId,
+    });
     reducerService.register(usSavingsIntCreditReducer);
 
-    const stockDividendCashReducer = new StockDividendCashApplyReducer({ accountService: svc });
+    const stockDividendCashReducer = new StockDividendCashApplyReducer({
+      accountService: svc,
+      stateRegistry,
+      role:    ACCOUNT_ROLES.US_SAVINGS,
+      ownerId: primaryId,
+    });
     reducerService.register(stockDividendCashReducer);
 
     const changeResidencyApplyReducer = new ChangeResidencyApplyReducer({ accountService: svc, stateRegistry });

--- a/src/scenarios/intl-retirement-scenario.js
+++ b/src/scenarios/intl-retirement-scenario.js
@@ -525,8 +525,9 @@ export class IntlRetirementScenario extends BaseScenario {
    * Called by ScenarioTabPresenter.afterBuildSim() when no saved config exists.
    */
   loadDefaults() {
-    const { eventService, handlerService, reducerService, accountService, personService } = ServiceRegistry.getInstance();
+    const { eventService, handlerService, reducerService, accountService, personService, stateRegistry } = ServiceRegistry.getInstance();
     const p = this._params;
+    const primaryId = this._people.primary.id;
 
     // ── TaxService phase 2: register handlers/reducers through the service layer
     this._taxService.registerHandlersAndReducers(ServiceRegistry.getInstance(), ['US', 'AU']);
@@ -619,22 +620,31 @@ export class IntlRetirementScenario extends BaseScenario {
     // ── Handlers ──────────────────────────────────────────────────────────────
 
     const expensesHandler = new MonthlyExpensesHandler({
+      stateRegistry,
       monthlyExpenses: p.monthlyExpenses,
+      usRole: ACCOUNT_ROLES.US_SAVINGS, usOwnerId: primaryId,
+      auRole: ACCOUNT_ROLES.AU_SAVINGS, auOwnerId: primaryId,
     });
     expensesHandler.handledEvents.push(expensesEvent);
     handlerService.register(expensesHandler);
 
-    const wagesHandler = new MonthlyWagesHandler();
+    const wagesHandler = new MonthlyWagesHandler({ stateRegistry });
     wagesHandler.handledEvents.push(wagesEvent);
     handlerService.register(wagesHandler);
 
     const usSavingsIntHandler = new UsSavingsInterestMonthlyHandler({
+      stateRegistry,
+      role:         ACCOUNT_ROLES.US_SAVINGS,
+      ownerId:      primaryId,
       interestRate: p.usSavingsInterestRate,
     });
     usSavingsIntHandler.handledEvents.push(usSavingsIntEvent);
     handlerService.register(usSavingsIntHandler);
 
     const dividendHandler = new DividendScheduledHandler({
+      stateRegistry,
+      role:         ACCOUNT_ROLES.US_STOCK,
+      ownerId:      primaryId,
       dividendRate: p.stockDividendRate,
       reinvest:     p.stockDividendReinvest,
     });
@@ -642,50 +652,98 @@ export class IntlRetirementScenario extends BaseScenario {
     handlerService.register(dividendHandler);
 
     const fixedIncomeHandler = new FixedIncomeInterestHandler({
+      stateRegistry,
+      role:         ACCOUNT_ROLES.FIXED_INCOME,
+      ownerId:      primaryId,
       interestRate: p.fixedIncomeInterestRate,
     });
     fixedIncomeHandler.handledEvents.push(fixedIncomeEvent);
     handlerService.register(fixedIncomeHandler);
 
     const auSavingsHandler = new AuSavingsInterestHandler({
+      stateRegistry,
+      role:         ACCOUNT_ROLES.AU_SAVINGS,
+      ownerId:      primaryId,
       interestRate: p.auSavingsInterestRate,
     });
     auSavingsHandler.handledEvents.push(auSavingsEvent);
     handlerService.register(auSavingsHandler);
 
-    const superHandler = new SuperEarningsHandler();
+    const superHandler = new SuperEarningsHandler({
+      stateRegistry,
+      role:    ACCOUNT_ROLES.SUPER,
+      ownerId: primaryId,
+    });
     superHandler.handledEvents.push(superEvent);
     handlerService.register(superHandler);
 
-    const rothEarningsHandler = new IntlRothEarningsHandler({ growthRate: p.rothGrowthRate });
+    const rothEarningsHandler = new IntlRothEarningsHandler({
+      stateRegistry,
+      role:       ACCOUNT_ROLES.ROTH,
+      ownerId:    primaryId,
+      growthRate: p.rothGrowthRate,
+    });
     rothEarningsHandler.handledEvents.push(rothEarningsEvent);
     handlerService.register(rothEarningsHandler);
 
-    const iraEarningsHandler = new IntlIraEarningsHandler({ growthRate: p.iraGrowthRate });
+    const iraEarningsHandler = new IntlIraEarningsHandler({
+      stateRegistry,
+      role:       ACCOUNT_ROLES.IRA,
+      ownerId:    primaryId,
+      growthRate: p.iraGrowthRate,
+    });
     iraEarningsHandler.handledEvents.push(iraEarningsEvent);
     handlerService.register(iraEarningsHandler);
 
-    const k401EarningsHandler = new IntlK401EarningsHandler({ growthRate: p.k401GrowthRate });
+    const k401EarningsHandler = new IntlK401EarningsHandler({
+      stateRegistry,
+      role:       ACCOUNT_ROLES.K401,
+      ownerId:    primaryId,
+      growthRate: p.k401GrowthRate,
+    });
     k401EarningsHandler.handledEvents.push(k401EarningsEvent);
     handlerService.register(k401EarningsHandler);
 
-    const usStockEarningsHandler = new IntlUsStockEarningsHandler({ growthRate: p.usStockGrowthRate });
+    const usStockEarningsHandler = new IntlUsStockEarningsHandler({
+      stateRegistry,
+      role:       ACCOUNT_ROLES.US_STOCK,
+      ownerId:    primaryId,
+      growthRate: p.usStockGrowthRate,
+    });
     usStockEarningsHandler.handledEvents.push(usStockEarningsEvent);
     handlerService.register(usStockEarningsHandler);
 
-    const auStockEarningsHandler = new IntlAuStockEarningsHandler({ growthRate: p.auStockGrowthRate });
+    const auStockEarningsHandler = new IntlAuStockEarningsHandler({
+      stateRegistry,
+      role:       ACCOUNT_ROLES.AU_STOCK,
+      ownerId:    primaryId,
+      growthRate: p.auStockGrowthRate,
+    });
     auStockEarningsHandler.handledEvents.push(auStockEarningsEvent);
     handlerService.register(auStockEarningsHandler);
 
-    const auStockDividendHandler = new IntlAuStockDividendHandler({ dividendRate: p.auStockDividendRate });
+    const auStockDividendHandler = new IntlAuStockDividendHandler({
+      stateRegistry,
+      role:         ACCOUNT_ROLES.AU_STOCK,
+      ownerId:      primaryId,
+      dividendRate: p.auStockDividendRate,
+    });
     auStockDividendHandler.handledEvents.push(auStockDividendEvent);
     handlerService.register(auStockDividendHandler);
 
     // User-triggered transfer handlers (no event series — fired on-demand)
-    const intlToUsHandler = new IntlTransferToUsHandler();
+    const intlToUsHandler = new IntlTransferToUsHandler({
+      stateRegistry,
+      auRole: ACCOUNT_ROLES.AU_SAVINGS, auOwnerId: primaryId,
+      usRole: ACCOUNT_ROLES.US_SAVINGS, usOwnerId: primaryId,
+    });
     handlerService.register(intlToUsHandler);
 
-    const intlToAuHandler = new IntlTransferToAuHandler();
+    const intlToAuHandler = new IntlTransferToAuHandler({
+      stateRegistry,
+      usRole: ACCOUNT_ROLES.US_SAVINGS, usOwnerId: primaryId,
+      auRole: ACCOUNT_ROLES.AU_SAVINGS, auOwnerId: primaryId,
+    });
     handlerService.register(intlToAuHandler);
 
     // CHANGE_RESIDENCY is scheduled directly in buildSim() (one-off)

--- a/src/scenarios/intl-retirement-scenario.js
+++ b/src/scenarios/intl-retirement-scenario.js
@@ -776,7 +776,7 @@ export class IntlRetirementScenario extends BaseScenario {
     const stockDividendCashReducer = new StockDividendCashApplyReducer({ accountService: svc });
     reducerService.register(stockDividendCashReducer);
 
-    const changeResidencyApplyReducer = new ChangeResidencyApplyReducer({ accountService: svc });
+    const changeResidencyApplyReducer = new ChangeResidencyApplyReducer({ accountService: svc, stateRegistry });
     reducerService.register(changeResidencyApplyReducer);
 
     const setOutOfFundsDateReducer = new SetOutOfFundsDateReducer();

--- a/src/scenarios/scenario-serializer.js
+++ b/src/scenarios/scenario-serializer.js
@@ -490,7 +490,7 @@ export class ScenarioSerializer {
         break;
       case 'DividendScheduledHandler':
         handler = new FinSimLib.Finance.DividendScheduledHandler({
-          accountKey:   d.accountKey   ?? 'stockAccount',
+          accountKey:   d.accountKey   ?? 'usStockAccount',
           dividendRate: d.dividendRate ?? 0.02,
           reinvest:     d.reinvest     ?? false,
         });

--- a/src/scenarios/scenario-serializer.js
+++ b/src/scenarios/scenario-serializer.js
@@ -11,6 +11,7 @@
 
 
 import { ActionDefinition } from '../simulation-framework/actions.js';
+import { ACCOUNT_ROLES } from '../finance/state/account-roles.js';
 
 // ─── Lookup sets for fast-path constructor dispatch ───────────────────────────
 
@@ -210,7 +211,7 @@ export class ScenarioSerializer {
     // 3. Handlers — resolve references before registering so the CREATE
     //    subscriber sees the fully-wired handler.
     for (const d of (config.handlers ?? [])) {
-      const handler = ScenarioSerializer._makeHandler(d);
+      const handler = ScenarioSerializer._makeHandler(d, services);
       for (const eid of (d.handledEventIds ?? [])) {
         const ev = eventMap.get(eid);
         if (ev) handler.handledEvents.push(ev);
@@ -323,40 +324,81 @@ export class ScenarioSerializer {
     // Subclass-specific params
     switch (d.__type) {
       case 'UsSavingsInterestMonthlyHandler':
-        d.accountKey   = node.accountKey;
+        d.role         = node.role;
+        d.ownerId      = node.ownerId;
         d.interestRate = node.interestRate;
         break;
       case 'MonthlyExpensesHandler':
         d.monthlyExpenses = node.monthlyExpenses;
-        d.usAccountKey    = node.usAccountKey;
-        d.auAccountKey    = node.auAccountKey;
+        d.usRole          = node.usRole;
+        d.usOwnerId       = node.usOwnerId;
+        d.auRole          = node.auRole;
+        d.auOwnerId       = node.auOwnerId;
         break;
       case 'IntlTransferToUsHandler':
-        d.auAccountKey = node.auAccountKey;
-        d.usAccountKey = node.usAccountKey;
+        d.auRole    = node.auRole;
+        d.auOwnerId = node.auOwnerId;
+        d.usRole    = node.usRole;
+        d.usOwnerId = node.usOwnerId;
         break;
       case 'IntlTransferToAuHandler':
-        d.usAccountKey = node.usAccountKey;
-        d.auAccountKey = node.auAccountKey;
+        d.usRole    = node.usRole;
+        d.usOwnerId = node.usOwnerId;
+        d.auRole    = node.auRole;
+        d.auOwnerId = node.auOwnerId;
         break;
       case 'AuSavingsInterestHandler':
-        d.accountKey   = node.accountKey;
+        d.role         = node.role;
+        d.ownerId      = node.ownerId;
         d.interestRate = node.interestRate;
         break;
       case 'FixedIncomeInterestHandler':
-        d.accountKey   = node.accountKey;
+        d.role         = node.role;
+        d.ownerId      = node.ownerId;
         d.interestRate = node.interestRate;
         break;
       case 'SuperEarningsHandler':
-        d.accountKey   = node.accountKey;
-        d.defaultRate  = node.defaultRate;
+        d.role        = node.role;
+        d.ownerId     = node.ownerId;
+        d.defaultRate = node.defaultRate;
         break;
       case 'DividendScheduledHandler':
-        d.accountKey   = node.accountKey;
+        d.role         = node.role;
+        d.ownerId      = node.ownerId;
         d.dividendRate = node.dividendRate;
         d.reinvest     = node.reinvest;
         break;
-      // ChangeResidencyHandler and OutOfFundsHandler have no serializable config params
+      case 'IntlRothEarningsHandler':
+        d.role      = node.role;
+        d.ownerId   = node.ownerId;
+        d.growthRate = node.growthRate;
+        break;
+      case 'IntlIraEarningsHandler':
+        d.role      = node.role;
+        d.ownerId   = node.ownerId;
+        d.growthRate = node.growthRate;
+        break;
+      case 'IntlK401EarningsHandler':
+        d.role      = node.role;
+        d.ownerId   = node.ownerId;
+        d.growthRate = node.growthRate;
+        break;
+      case 'IntlUsStockEarningsHandler':
+        d.role      = node.role;
+        d.ownerId   = node.ownerId;
+        d.growthRate = node.growthRate;
+        break;
+      case 'IntlAuStockEarningsHandler':
+        d.role      = node.role;
+        d.ownerId   = node.ownerId;
+        d.growthRate = node.growthRate;
+        break;
+      case 'IntlAuStockDividendHandler':
+        d.role         = node.role;
+        d.ownerId      = node.ownerId;
+        d.dividendRate = node.dividendRate;
+        break;
+      // ChangeResidencyHandler, MonthlyWagesHandler, OutOfFundsHandler have no serializable config params
     }
     return d;
   }
@@ -432,10 +474,15 @@ export class ScenarioSerializer {
 
   /**
    * Reconstruct a HandlerEntry or subclass from its serialized descriptor.
-   * Subclass-specific params (e.g. interestRate, accountKey) are stored on the
-   * descriptor and forwarded to the constructor.
+   * Subclass-specific params (role, ownerId, rates) are restored from the
+   * descriptor; stateRegistry is injected from services.
+   *
+   * @param {object} d        - serialized handler descriptor
+   * @param {object} services - ServiceRegistry instance (provides stateRegistry)
    */
-  static _makeHandler(d) {
+  static _makeHandler(d, services) {
+    const stateRegistry = services?.stateRegistry;
+
     // ── No-arg account-module and tax-infrastructure handlers ─────────────────
     if (_NO_ARG_HANDLERS.has(d.__type)) {
       const handler = new FinSimLib.Finance[d.__type]();
@@ -447,52 +494,122 @@ export class ScenarioSerializer {
     switch (d.__type) {
       case 'UsSavingsInterestMonthlyHandler':
         handler = new FinSimLib.Finance.UsSavingsInterestMonthlyHandler({
-          accountKey:   d.accountKey   ?? 'usSavingsAccount',
+          stateRegistry,
+          role:         d.role    ?? ACCOUNT_ROLES.US_SAVINGS,
+          ownerId:      d.ownerId ?? null,
           interestRate: d.interestRate ?? 0.03,
         });
         break;
       case 'MonthlyExpensesHandler':
         handler = new FinSimLib.Finance.MonthlyExpensesHandler({
+          stateRegistry,
           monthlyExpenses: d.monthlyExpenses ?? 6000,
-          usAccountKey:    d.usAccountKey    ?? 'usSavingsAccount',
-          auAccountKey:    d.auAccountKey    ?? 'auSavingsAccount',
+          usRole:    d.usRole    ?? ACCOUNT_ROLES.US_SAVINGS,
+          usOwnerId: d.usOwnerId ?? null,
+          auRole:    d.auRole    ?? ACCOUNT_ROLES.AU_SAVINGS,
+          auOwnerId: d.auOwnerId ?? null,
         });
+        break;
+      case 'MonthlyWagesHandler':
+        handler = new FinSimLib.Finance.MonthlyWagesHandler({ stateRegistry });
         break;
       case 'IntlTransferToUsHandler':
         handler = new FinSimLib.Finance.IntlTransferToUsHandler({
-          auAccountKey: d.auAccountKey ?? 'auSavingsAccount',
-          usAccountKey: d.usAccountKey ?? 'usSavingsAccount',
+          stateRegistry,
+          auRole:    d.auRole    ?? ACCOUNT_ROLES.AU_SAVINGS,
+          auOwnerId: d.auOwnerId ?? null,
+          usRole:    d.usRole    ?? ACCOUNT_ROLES.US_SAVINGS,
+          usOwnerId: d.usOwnerId ?? null,
         });
         break;
       case 'IntlTransferToAuHandler':
         handler = new FinSimLib.Finance.IntlTransferToAuHandler({
-          usAccountKey: d.usAccountKey ?? 'usSavingsAccount',
-          auAccountKey: d.auAccountKey ?? 'auSavingsAccount',
+          stateRegistry,
+          usRole:    d.usRole    ?? ACCOUNT_ROLES.US_SAVINGS,
+          usOwnerId: d.usOwnerId ?? null,
+          auRole:    d.auRole    ?? ACCOUNT_ROLES.AU_SAVINGS,
+          auOwnerId: d.auOwnerId ?? null,
         });
         break;
       case 'AuSavingsInterestHandler':
         handler = new FinSimLib.Finance.AuSavingsInterestHandler({
-          accountKey:   d.accountKey   ?? 'auSavingsAccount',
+          stateRegistry,
+          role:         d.role    ?? ACCOUNT_ROLES.AU_SAVINGS,
+          ownerId:      d.ownerId ?? null,
           interestRate: d.interestRate ?? 0.045,
         });
         break;
       case 'FixedIncomeInterestHandler':
         handler = new FinSimLib.Finance.FixedIncomeInterestHandler({
-          accountKey:   d.accountKey   ?? 'fixedIncomeAccount',
+          stateRegistry,
+          role:         d.role    ?? ACCOUNT_ROLES.FIXED_INCOME,
+          ownerId:      d.ownerId ?? null,
           interestRate: d.interestRate ?? 0.04,
         });
         break;
       case 'SuperEarningsHandler':
         handler = new FinSimLib.Finance.SuperEarningsHandler({
-          accountKey:  d.accountKey  ?? 'superAccount',
+          stateRegistry,
+          role:        d.role    ?? ACCOUNT_ROLES.SUPER,
+          ownerId:     d.ownerId ?? null,
           defaultRate: d.defaultRate ?? 0.07,
         });
         break;
       case 'DividendScheduledHandler':
         handler = new FinSimLib.Finance.DividendScheduledHandler({
-          accountKey:   d.accountKey   ?? 'usStockAccount',
+          stateRegistry,
+          role:         d.role    ?? ACCOUNT_ROLES.US_STOCK,
+          ownerId:      d.ownerId ?? null,
           dividendRate: d.dividendRate ?? 0.02,
           reinvest:     d.reinvest     ?? false,
+        });
+        break;
+      case 'IntlRothEarningsHandler':
+        handler = new FinSimLib.Finance.IntlRothEarningsHandler({
+          stateRegistry,
+          role:       d.role    ?? ACCOUNT_ROLES.ROTH,
+          ownerId:    d.ownerId ?? null,
+          growthRate: d.growthRate ?? 0.07,
+        });
+        break;
+      case 'IntlIraEarningsHandler':
+        handler = new FinSimLib.Finance.IntlIraEarningsHandler({
+          stateRegistry,
+          role:       d.role    ?? ACCOUNT_ROLES.IRA,
+          ownerId:    d.ownerId ?? null,
+          growthRate: d.growthRate ?? 0.07,
+        });
+        break;
+      case 'IntlK401EarningsHandler':
+        handler = new FinSimLib.Finance.IntlK401EarningsHandler({
+          stateRegistry,
+          role:       d.role    ?? ACCOUNT_ROLES.K401,
+          ownerId:    d.ownerId ?? null,
+          growthRate: d.growthRate ?? 0.07,
+        });
+        break;
+      case 'IntlUsStockEarningsHandler':
+        handler = new FinSimLib.Finance.IntlUsStockEarningsHandler({
+          stateRegistry,
+          role:       d.role    ?? ACCOUNT_ROLES.US_STOCK,
+          ownerId:    d.ownerId ?? null,
+          growthRate: d.growthRate ?? 0.05,
+        });
+        break;
+      case 'IntlAuStockEarningsHandler':
+        handler = new FinSimLib.Finance.IntlAuStockEarningsHandler({
+          stateRegistry,
+          role:       d.role    ?? ACCOUNT_ROLES.AU_STOCK,
+          ownerId:    d.ownerId ?? null,
+          growthRate: d.growthRate ?? 0.06,
+        });
+        break;
+      case 'IntlAuStockDividendHandler':
+        handler = new FinSimLib.Finance.IntlAuStockDividendHandler({
+          stateRegistry,
+          role:         d.role    ?? ACCOUNT_ROLES.AU_STOCK,
+          ownerId:      d.ownerId ?? null,
+          dividendRate: d.dividendRate ?? 0.04,
         });
         break;
       case 'ChangeResidencyHandler':

--- a/src/scenarios/scenario-serializer.js
+++ b/src/scenarios/scenario-serializer.js
@@ -458,8 +458,8 @@ export class ScenarioSerializer {
       case 'StockDividendCashApplyReducer':
         d.accountKey = node.accountKey;
         break;
+      // ChangeResidencyApplyReducer has no extra serializable config params
       case 'ChangeResidencyApplyReducer':
-        d.investmentKeys = node.investmentKeys;
         break;
       // SetOutOfFundsDateReducer has no serializable config params
       case 'DynamicTaxReducer':
@@ -738,7 +738,7 @@ export class ScenarioSerializer {
       case 'TaxSettleApplyReducer':
         return new F.TaxSettleApplyReducer();
       case 'TaxPaymentDebitReducer':
-        return new F.TaxPaymentDebitReducer({ accountService: services?.accountService });
+        return new F.TaxPaymentDebitReducer({ accountService: services?.accountService, stateRegistry: services?.stateRegistry });
       case 'DynamicTaxReducer': {
         // TaxEngine is reconstructed from a fresh TaxService — all year modules are pre-registered.
         const taxEngine  = new F.TaxService().taxEngine;
@@ -797,8 +797,8 @@ export class ScenarioSerializer {
         });
       case 'ChangeResidencyApplyReducer':
         return new FinSimLib.Finance.ChangeResidencyApplyReducer({
-          accountService:  services?.accountService,
-          ...(d.investmentKeys ? { investmentKeys: d.investmentKeys } : {}),
+          accountService: services?.accountService,
+          stateRegistry:  services?.stateRegistry,
         });
       case 'SetOutOfFundsDateReducer':
         return new FinSimLib.Finance.SetOutOfFundsDateReducer();

--- a/src/scenarios/scenario-serializer.js
+++ b/src/scenarios/scenario-serializer.js
@@ -445,7 +445,8 @@ export class ScenarioSerializer {
     // Subclass-specific params
     switch (d.__type) {
       case 'UsSavingsInterestCreditReducer':
-        d.accountKey = node.accountKey;
+        d.role    = node.role;
+        d.ownerId = node.ownerId;
         break;
       case 'ExpenseDebitReducer':
         d.usAccountKey = node.usAccountKey;
@@ -457,7 +458,8 @@ export class ScenarioSerializer {
         d.auSavingsKey = node.auSavingsKey;
         break;
       case 'StockDividendCashApplyReducer':
-        d.accountKey = node.accountKey;
+        d.role    = node.role;
+        d.ownerId = node.ownerId;
         break;
       // ChangeResidencyApplyReducer has no extra serializable config params
       case 'ChangeResidencyApplyReducer':
@@ -774,7 +776,9 @@ export class ScenarioSerializer {
       case 'UsSavingsInterestCreditReducer':
         return new FinSimLib.Finance.UsSavingsInterestCreditReducer({
           accountService: services?.accountService,
-          accountKey:     d.accountKey ?? 'usSavingsAccount',
+          stateRegistry:  services?.stateRegistry,
+          role:           d.role    ?? ACCOUNT_ROLES.US_SAVINGS,
+          ownerId:        d.ownerId ?? null,
         });
       case 'ExpenseDebitReducer':
         return new FinSimLib.Finance.ExpenseDebitReducer({
@@ -795,7 +799,9 @@ export class ScenarioSerializer {
       case 'StockDividendCashApplyReducer':
         return new FinSimLib.Finance.StockDividendCashApplyReducer({
           accountService: services?.accountService,
-          accountKey:     d.accountKey ?? 'usSavingsAccount',
+          stateRegistry:  services?.stateRegistry,
+          role:           d.role    ?? ACCOUNT_ROLES.US_SAVINGS,
+          ownerId:        d.ownerId ?? null,
         });
       case 'ChangeResidencyApplyReducer':
         return new FinSimLib.Finance.ChangeResidencyApplyReducer({

--- a/src/scenarios/scenario-serializer.js
+++ b/src/scenarios/scenario-serializer.js
@@ -255,6 +255,7 @@ export class ScenarioSerializer {
       id:               account.id,
       name:             account.name             ?? '',
       type:             account.type             ?? null,
+      role:             account.role             ?? null,
       initialValue:     account.balance,
       ownershipType:    account.ownershipType    ?? 'sole',
       ownerId:          account.ownerId          ?? null,
@@ -631,6 +632,7 @@ export class ScenarioSerializer {
     const opts = {
       id:               d.id,
       name:             d.name             ?? '',
+      role:             d.role             ?? null,
       ownershipType:    d.ownershipType    ?? 'sole',
       ownerId:          d.ownerId          ?? null,
       minimumBalance:   d.minimumBalance   ?? 0,

--- a/src/services/handler-service.js
+++ b/src/services/handler-service.js
@@ -157,16 +157,16 @@ export class HandlerService extends BaseService {
 
   /**
    * Create and register a UsSavingsInterestMonthlyHandler.
-   * Wire the handler to an event by adding the EventSeries to handler.handledEvents
-   * before calling this, or call updateHandler(id, { handledEvents: [...] }) after.
    *
-   * @param {object} [opts]
-   * @param {string} [opts.accountKey='usSavingsAccount']
+   * @param {object} opts
+   * @param {import('../finance/services/state-registry.js').StateRegistry} opts.stateRegistry
+   * @param {string} opts.role       - ACCOUNT_ROLES value for the savings account
+   * @param {string} [opts.ownerId]  - Person id (null = any owner)
    * @param {number} [opts.interestRate=0.03]
    * @param {string} [opts.name='Monthly US Savings Interest']
    */
-  createUsSavingsInterestHandler({ accountKey = 'usSavingsAccount', interestRate = 0.03, name = 'Monthly US Savings Interest' } = {}) {
-    const item = new UsSavingsInterestMonthlyHandler({ accountKey, interestRate });
+  createUsSavingsInterestHandler({ stateRegistry, role, ownerId = null, interestRate = 0.03, name = 'Monthly US Savings Interest' } = {}) {
+    const item = new UsSavingsInterestMonthlyHandler({ stateRegistry, role, ownerId, interestRate });
     item.name = name;
     item.id   = this._generateId('h');
     this._register(item);
@@ -177,14 +177,18 @@ export class HandlerService extends BaseService {
 
   /**
    * Create and register a MonthlyExpensesHandler.
-   * @param {object} [opts]
+   *
+   * @param {object} opts
+   * @param {import('../finance/services/state-registry.js').StateRegistry} opts.stateRegistry
    * @param {number} [opts.monthlyExpenses=6000]
-   * @param {string} [opts.usAccountKey='usSavingsAccount']
-   * @param {string} [opts.auAccountKey='auSavingsAccount']
+   * @param {string} opts.usRole      - ACCOUNT_ROLES value for the USD cash pool
+   * @param {string} [opts.usOwnerId]
+   * @param {string} opts.auRole      - ACCOUNT_ROLES value for the AUD cash pool
+   * @param {string} [opts.auOwnerId]
    * @param {string} [opts.name='Monthly Expenses']
    */
-  createMonthlyExpensesHandler({ monthlyExpenses = 6000, usAccountKey = 'usSavingsAccount', auAccountKey = 'auSavingsAccount', name = 'Monthly Expenses' } = {}) {
-    const item = new MonthlyExpensesHandler({ monthlyExpenses, usAccountKey, auAccountKey });
+  createMonthlyExpensesHandler({ stateRegistry, monthlyExpenses = 6000, usRole, usOwnerId = null, auRole, auOwnerId = null, name = 'Monthly Expenses' } = {}) {
+    const item = new MonthlyExpensesHandler({ stateRegistry, monthlyExpenses, usRole, usOwnerId, auRole, auOwnerId });
     item.name = name;
     item.id   = this._generateId('h');
     this._register(item);
@@ -195,13 +199,17 @@ export class HandlerService extends BaseService {
 
   /**
    * Create and register an IntlTransferToUsHandler (AUD → USD, user-triggered).
-   * @param {object} [opts]
-   * @param {string} [opts.auAccountKey='auSavingsAccount']
-   * @param {string} [opts.usAccountKey='usSavingsAccount']
+   *
+   * @param {object} opts
+   * @param {import('../finance/services/state-registry.js').StateRegistry} opts.stateRegistry
+   * @param {string} opts.auRole
+   * @param {string} [opts.auOwnerId]
+   * @param {string} opts.usRole
+   * @param {string} [opts.usOwnerId]
    * @param {string} [opts.name='International Transfer to US']
    */
-  createIntlTransferToUsHandler({ auAccountKey = 'auSavingsAccount', usAccountKey = 'usSavingsAccount', name = 'International Transfer to US' } = {}) {
-    const item = new IntlTransferToUsHandler({ auAccountKey, usAccountKey });
+  createIntlTransferToUsHandler({ stateRegistry, auRole, auOwnerId = null, usRole, usOwnerId = null, name = 'International Transfer to US' } = {}) {
+    const item = new IntlTransferToUsHandler({ stateRegistry, auRole, auOwnerId, usRole, usOwnerId });
     item.name = name;
     item.id   = this._generateId('h');
     this._register(item);
@@ -212,13 +220,17 @@ export class HandlerService extends BaseService {
 
   /**
    * Create and register an IntlTransferToAuHandler (USD → AUD, user-triggered).
-   * @param {object} [opts]
-   * @param {string} [opts.usAccountKey='usSavingsAccount']
-   * @param {string} [opts.auAccountKey='auSavingsAccount']
+   *
+   * @param {object} opts
+   * @param {import('../finance/services/state-registry.js').StateRegistry} opts.stateRegistry
+   * @param {string} opts.usRole
+   * @param {string} [opts.usOwnerId]
+   * @param {string} opts.auRole
+   * @param {string} [opts.auOwnerId]
    * @param {string} [opts.name='International Transfer to AU']
    */
-  createIntlTransferToAuHandler({ usAccountKey = 'usSavingsAccount', auAccountKey = 'auSavingsAccount', name = 'International Transfer to AU' } = {}) {
-    const item = new IntlTransferToAuHandler({ usAccountKey, auAccountKey });
+  createIntlTransferToAuHandler({ stateRegistry, usRole, usOwnerId = null, auRole, auOwnerId = null, name = 'International Transfer to AU' } = {}) {
+    const item = new IntlTransferToAuHandler({ stateRegistry, usRole, usOwnerId, auRole, auOwnerId });
     item.name = name;
     item.id   = this._generateId('h');
     this._register(item);
@@ -229,13 +241,16 @@ export class HandlerService extends BaseService {
 
   /**
    * Create and register an AuSavingsInterestHandler.
-   * @param {object} [opts]
-   * @param {string} [opts.accountKey='auSavingsAccount']
+   *
+   * @param {object} opts
+   * @param {import('../finance/services/state-registry.js').StateRegistry} opts.stateRegistry
+   * @param {string} opts.role
+   * @param {string} [opts.ownerId]
    * @param {number} [opts.interestRate=0.045]
    * @param {string} [opts.name='AU Savings Interest']
    */
-  createAuSavingsInterestHandler({ accountKey = 'auSavingsAccount', interestRate = 0.045, name = 'AU Savings Interest' } = {}) {
-    const item = new AuSavingsInterestHandler({ accountKey, interestRate });
+  createAuSavingsInterestHandler({ stateRegistry, role, ownerId = null, interestRate = 0.045, name = 'AU Savings Interest' } = {}) {
+    const item = new AuSavingsInterestHandler({ stateRegistry, role, ownerId, interestRate });
     item.name = name;
     item.id   = this._generateId('h');
     this._register(item);
@@ -246,13 +261,16 @@ export class HandlerService extends BaseService {
 
   /**
    * Create and register a FixedIncomeInterestHandler.
-   * @param {object} [opts]
-   * @param {string} [opts.accountKey='fixedIncomeAccount']
+   *
+   * @param {object} opts
+   * @param {import('../finance/services/state-registry.js').StateRegistry} opts.stateRegistry
+   * @param {string} opts.role
+   * @param {string} [opts.ownerId]
    * @param {number} [opts.interestRate=0.04]
    * @param {string} [opts.name='Fixed Income Interest']
    */
-  createFixedIncomeInterestHandler({ accountKey = 'fixedIncomeAccount', interestRate = 0.04, name = 'Fixed Income Interest' } = {}) {
-    const item = new FixedIncomeInterestHandler({ accountKey, interestRate });
+  createFixedIncomeInterestHandler({ stateRegistry, role, ownerId = null, interestRate = 0.04, name = 'Fixed Income Interest' } = {}) {
+    const item = new FixedIncomeInterestHandler({ stateRegistry, role, ownerId, interestRate });
     item.name = name;
     item.id   = this._generateId('h');
     this._register(item);
@@ -263,13 +281,16 @@ export class HandlerService extends BaseService {
 
   /**
    * Create and register a SuperEarningsHandler.
-   * @param {object} [opts]
-   * @param {string} [opts.accountKey='superAccount']
+   *
+   * @param {object} opts
+   * @param {import('../finance/services/state-registry.js').StateRegistry} opts.stateRegistry
+   * @param {string} opts.role
+   * @param {string} [opts.ownerId]
    * @param {number} [opts.defaultRate=0.07]
    * @param {string} [opts.name='Super Earnings']
    */
-  createSuperEarningsHandler({ accountKey = 'superAccount', defaultRate = 0.07, name = 'Super Earnings' } = {}) {
-    const item = new SuperEarningsHandler({ accountKey, defaultRate });
+  createSuperEarningsHandler({ stateRegistry, role, ownerId = null, defaultRate = 0.07, name = 'Super Earnings' } = {}) {
+    const item = new SuperEarningsHandler({ stateRegistry, role, ownerId, defaultRate });
     item.name = name;
     item.id   = this._generateId('h');
     this._register(item);
@@ -280,14 +301,17 @@ export class HandlerService extends BaseService {
 
   /**
    * Create and register a DividendScheduledHandler.
-   * @param {object} [opts]
-   * @param {string}  [opts.accountKey='stockAccount']
+   *
+   * @param {object} opts
+   * @param {import('../finance/services/state-registry.js').StateRegistry} opts.stateRegistry
+   * @param {string} opts.role
+   * @param {string} [opts.ownerId]
    * @param {number}  [opts.dividendRate=0.02]
    * @param {boolean} [opts.reinvest=false]
    * @param {string}  [opts.name='Dividend Scheduled']
    */
-  createDividendScheduledHandler({ accountKey = 'usStockAccount', dividendRate = 0.02, reinvest = false, name = 'Dividend Scheduled' } = {}) {
-    const item = new DividendScheduledHandler({ accountKey, dividendRate, reinvest });
+  createDividendScheduledHandler({ stateRegistry, role, ownerId = null, dividendRate = 0.02, reinvest = false, name = 'Dividend Scheduled' } = {}) {
+    const item = new DividendScheduledHandler({ stateRegistry, role, ownerId, dividendRate, reinvest });
     item.name = name;
     item.id   = this._generateId('h');
     this._register(item);

--- a/src/services/handler-service.js
+++ b/src/services/handler-service.js
@@ -286,7 +286,7 @@ export class HandlerService extends BaseService {
    * @param {boolean} [opts.reinvest=false]
    * @param {string}  [opts.name='Dividend Scheduled']
    */
-  createDividendScheduledHandler({ accountKey = 'stockAccount', dividendRate = 0.02, reinvest = false, name = 'Dividend Scheduled' } = {}) {
+  createDividendScheduledHandler({ accountKey = 'usStockAccount', dividendRate = 0.02, reinvest = false, name = 'Dividend Scheduled' } = {}) {
     const item = new DividendScheduledHandler({ accountKey, dividendRate, reinvest });
     item.name = name;
     item.id   = this._generateId('h');

--- a/src/services/reducer-service.js
+++ b/src/services/reducer-service.js
@@ -136,11 +136,13 @@ export class ReducerService extends BaseService {
    * Create and register a UsSavingsInterestCreditReducer.
    * @param {import('../finance/services/account-service.js').AccountService} accountService
    * @param {object} [opts]
-   * @param {string} [opts.accountKey='usSavingsAccount']
+   * @param {import('../finance/services/state-registry.js').StateRegistry} [opts.stateRegistry]
+   * @param {string} [opts.role]
+   * @param {string|null} [opts.ownerId]
    * @param {string} [opts.name='US Savings Interest Credit']
    */
-  createUsSavingsInterestCreditReducer(accountService, { accountKey = 'usSavingsAccount', name = 'US Savings Interest Credit' } = {}) {
-    const item = new UsSavingsInterestCreditReducer({ accountService, accountKey });
+  createUsSavingsInterestCreditReducer(accountService, { stateRegistry, role, ownerId = null, name = 'US Savings Interest Credit' } = {}) {
+    const item = new UsSavingsInterestCreditReducer({ accountService, stateRegistry, role, ownerId });
     item.name = name;
     item.id   = this._generateId('r');
     this._register(item);
@@ -205,11 +207,13 @@ export class ReducerService extends BaseService {
    * Create and register a StockDividendCashApplyReducer.
    * @param {import('../finance/services/account-service.js').AccountService} accountService
    * @param {object} [opts]
-   * @param {string} [opts.accountKey='usSavingsAccount']
+   * @param {import('../finance/services/state-registry.js').StateRegistry} [opts.stateRegistry]
+   * @param {string} [opts.role]
+   * @param {string|null} [opts.ownerId]
    * @param {string} [opts.name='Stock Dividend Cash Apply']
    */
-  createStockDividendCashApplyReducer(accountService, { accountKey = 'usSavingsAccount', name = 'Stock Dividend Cash Apply' } = {}) {
-    const item = new StockDividendCashApplyReducer({ accountService, accountKey });
+  createStockDividendCashApplyReducer(accountService, { stateRegistry, role, ownerId = null, name = 'Stock Dividend Cash Apply' } = {}) {
+    const item = new StockDividendCashApplyReducer({ accountService, stateRegistry, role, ownerId });
     item.name = name;
     item.id   = this._generateId('r');
     this._register(item);

--- a/src/services/service-registry.js
+++ b/src/services/service-registry.js
@@ -22,6 +22,7 @@ import {GraphQueryApi} from "../graph/graph-query-api.js";
 import {ScenarioService} from "./scenario-service.js";
 import {ScenarioStorage} from "../scenarios/scenario-storage.js";
 import {ScenarioRegistry} from "../scenarios/scenario-registry.js";
+import { StateRegistry } from '../finance/services/state-registry.js';
 
 /**
  * Central singleton registry for all application services, the shared
@@ -49,6 +50,7 @@ export class ServiceRegistry {
     this.personService      = new PersonService(this.graph, this.graphQueryApi, this.bus);
     this.reducerService     = new ReducerService(this.graph, this.graphQueryApi, this.bus);
 
+    this.stateRegistry      = new StateRegistry({ accountService: this.accountService });
     this.scenarioRegistry   = new ScenarioRegistry(new ScenarioStorage());
     this.scenarioService    = new ScenarioService(this.bus, this.scenarioRegistry);
     this.simulationRegistry = new SimulationRegistry();

--- a/tests/unit/evt-us-brokerage.test.mjs
+++ b/tests/unit/evt-us-brokerage.test.mjs
@@ -56,7 +56,7 @@ function buildBrokerageSim({
   const sim = new Simulation(START_DATE, { initialState: new FinancialState({
     checkingAccount: new Account(initialChecking),
     fixedIncomeAccount: { balance: fixedIncomeBalance },
-    stockAccount: {
+    usStockAccount: {
       balance:           stockBalance,
       contributionBasis: stockContribBasis,
       earningsBasis:     stockEarningsBasis,
@@ -149,14 +149,14 @@ test('EVT-11: Fixed income earnings are NOT AU taxable if person is not AU resid
 // EVT-12: Stock Contribution
 // ══════════════════════════════════════════════════════════════════════════════
 
-test('EVT-12: Stock contribution increases stockAccount contributionBasis and debits checking', () => {
+test('EVT-12: Stock contribution increases usStockAccount contributionBasis and debits checking', () => {
   const { sim } = buildBrokerageSim({ initialChecking: 10000 });
   sim.schedule({ date: new Date(2026, 0, 15), type: 'STOCK_CONTRIBUTION', data: { amount: 5000 } });
   sim.stepTo(new Date(2026, 0, 31));
 
-  assert.strictEqual(sim.state.stockAccount.balance, 5000);
-  assert.strictEqual(sim.state.stockAccount.contributionBasis, 5000);
-  assert.strictEqual(sim.state.stockAccount.earningsBasis, 0);
+  assert.strictEqual(sim.state.usStockAccount.balance, 5000);
+  assert.strictEqual(sim.state.usStockAccount.contributionBasis, 5000);
+  assert.strictEqual(sim.state.usStockAccount.earningsBasis, 0);
   assert.strictEqual(sim.state.checkingAccount.balance, 5000);
   assert.strictEqual(sim.state.usOrdinaryIncomeYTD, 0);
 });
@@ -174,9 +174,9 @@ test('EVT-13: Stock dividend stays in account and increases both basis fields', 
   sim.schedule({ date: new Date(2026, 0, 15), type: 'STOCK_DIVIDEND', data: { amount: 1000 } });
   sim.stepTo(new Date(2026, 0, 31));
 
-  assert.strictEqual(sim.state.stockAccount.balance, 51000);
-  assert.strictEqual(sim.state.stockAccount.contributionBasis, 51000);
-  assert.strictEqual(sim.state.stockAccount.earningsBasis, 1000);
+  assert.strictEqual(sim.state.usStockAccount.balance, 51000);
+  assert.strictEqual(sim.state.usStockAccount.contributionBasis, 51000);
+  assert.strictEqual(sim.state.usStockAccount.earningsBasis, 1000);
   assert.strictEqual(sim.state.checkingAccount.balance, 5000); // unchanged
 });
 
@@ -219,8 +219,8 @@ test('EVT-14: Stock earnings stay in account, increase earningsBasis, no tax', (
   sim.schedule({ date: new Date(2026, 0, 15), type: 'STOCK_EARNINGS', data: { amount: 5000 } });
   sim.stepTo(new Date(2026, 0, 31));
 
-  assert.strictEqual(sim.state.stockAccount.balance, 55000);
-  assert.strictEqual(sim.state.stockAccount.earningsBasis, 5000);
+  assert.strictEqual(sim.state.usStockAccount.balance, 55000);
+  assert.strictEqual(sim.state.usStockAccount.earningsBasis, 5000);
   assert.strictEqual(sim.state.checkingAccount.balance, 5000);    // unchanged
   assert.strictEqual(sim.state.usOrdinaryIncomeYTD, 0);
   assert.strictEqual(sim.state.auOrdinaryIncomeYTD, 0);

--- a/tests/unit/intl-retirement-scenario.test.mjs
+++ b/tests/unit/intl-retirement-scenario.test.mjs
@@ -56,7 +56,11 @@ import { UsSavingsInterestMonthlyHandler }                                      
 import { MonthlyExpensesHandler }                                                    from '../../src/finance/handlers/monthly-expenses-handler.js';
 import { MonthlyWagesHandler }                                                       from '../../src/finance/handlers/monthly-wages-handler.js';
 import { IntlTransferToUsHandler, IntlTransferToAuHandler }                          from '../../src/finance/handlers/intl-transfer-handlers.js';
-import { AuSavingsInterestHandler, FixedIncomeInterestHandler, SuperEarningsHandler } from '../../src/finance/handlers/earnings-handlers.js';
+import {
+  AuSavingsInterestHandler, FixedIncomeInterestHandler, SuperEarningsHandler,
+  IntlRothEarningsHandler, IntlIraEarningsHandler, IntlK401EarningsHandler,
+  IntlUsStockEarningsHandler, IntlAuStockEarningsHandler, IntlAuStockDividendHandler,
+} from '../../src/finance/handlers/earnings-handlers.js';
 import { DividendScheduledHandler }                                                  from '../../src/finance/handlers/dividend-scheduled-handler.js';
 import { ChangeResidencyHandler }                                                    from '../../src/finance/handlers/change-residency-handler.js';
 import { OutOfFundsHandler }                                                         from '../../src/finance/handlers/out-of-funds-handler.js';
@@ -146,6 +150,8 @@ globalThis.FinSimLib = {
     IntlTransferToUsHandler, IntlTransferToAuHandler,
     AuSavingsInterestHandler, FixedIncomeInterestHandler, SuperEarningsHandler,
     DividendScheduledHandler, ChangeResidencyHandler, OutOfFundsHandler,
+    IntlRothEarningsHandler, IntlIraEarningsHandler, IntlK401EarningsHandler,
+    IntlUsStockEarningsHandler, IntlAuStockEarningsHandler, IntlAuStockDividendHandler,
     ChangeResidencyApplyReducer, ExpenseDebitReducer, IntlTransferApplyReducer,
     ReplenishSavingsReducer, SetOutOfFundsDateReducer, InflationAdjustReducer,
     StockDividendCashApplyReducer, UsSavingsInterestCreditReducer,

--- a/tests/unit/intl-retirement-scenario.test.mjs
+++ b/tests/unit/intl-retirement-scenario.test.mjs
@@ -409,18 +409,18 @@ test('serialize → deserialize round-trip reconstructs all TaxService handlers'
 // Metrics: investment account balances captured in state.metrics
 // ═════════════════════════════════════════════════════════════════════════════
 
-test('DIVIDEND_SCHEDULED: state.metrics.stockAccount is set after year-end dividend', () => {
+test('DIVIDEND_SCHEDULED: state.metrics.usStockAccount is set after year-end dividend', () => {
   // dividendsEvent has startOffset(1), so first DIVIDEND_SCHEDULED fires Dec 31 2027
   const { sim } = buildScenario();
   sim.stepTo(new Date(Date.UTC(2027, 11, 31)));
 
   assert.ok(
-    sim.state.metrics?.stockAccount != null,
-    `state.metrics.stockAccount should be set after DIVIDEND_SCHEDULED; got ${JSON.stringify(sim.state.metrics)}`
+    sim.state.metrics?.usStockAccount != null,
+    `state.metrics.usStockAccount should be set after DIVIDEND_SCHEDULED; got ${JSON.stringify(sim.state.metrics)}`
   );
   assert.ok(
-    typeof sim.state.metrics.stockAccount === 'number' && sim.state.metrics.stockAccount > 0,
-    `state.metrics.stockAccount should be a positive number, got ${sim.state.metrics.stockAccount}`
+    typeof sim.state.metrics.usStockAccount === 'number' && sim.state.metrics.usStockAccount > 0,
+    `state.metrics.usStockAccount should be a positive number, got ${sim.state.metrics.usStockAccount}`
   );
 });
 

--- a/tests/unit/intl-retirement-scenario.test.mjs
+++ b/tests/unit/intl-retirement-scenario.test.mjs
@@ -576,3 +576,131 @@ test('EW-INTL-3: early retirement draws from retirement accounts before triggeri
     `outOfFundsDate should remain null; got ${sim.state.outOfFundsDate}`
   );
 });
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Spouse retirement accounts — Session 4 additions
+// Verify that all 4 spouse accounts exist in state with correct roles/ownerIds,
+// and that their balances grow via the earnings handlers.
+// ═════════════════════════════════════════════════════════════════════════════
+
+test('SPOUSE-1: spouse retirement accounts exist in initial state', () => {
+  const { sim } = buildScenario();
+  const s = sim.state;
+
+  assert.ok(s.spouseRothAccount,  'spouseRothAccount missing from state');
+  assert.ok(s.spouseIraAccount,   'spouseIraAccount missing from state');
+  assert.ok(s.spouseK401Account,  'spouseK401Account missing from state');
+  assert.ok(s.spouseSuperAccount, 'spouseSuperAccount missing from state');
+});
+
+test('SPOUSE-2: spouse accounts have correct role and ownerId', () => {
+  const { sim } = buildScenario();
+  const s = sim.state;
+
+  assert.strictEqual(s.spouseRothAccount.role,    'roth-ira', 'spouseRothAccount.role');
+  assert.strictEqual(s.spouseIraAccount.role,     'ira',      'spouseIraAccount.role');
+  assert.strictEqual(s.spouseK401Account.role,    'k401',     'spouseK401Account.role');
+  assert.strictEqual(s.spouseSuperAccount.role,   'super',    'spouseSuperAccount.role');
+
+  assert.strictEqual(s.spouseRothAccount.ownerId,  'spouse', 'spouseRothAccount.ownerId');
+  assert.strictEqual(s.spouseIraAccount.ownerId,   'spouse', 'spouseIraAccount.ownerId');
+  assert.strictEqual(s.spouseK401Account.ownerId,  'spouse', 'spouseK401Account.ownerId');
+  assert.strictEqual(s.spouseSuperAccount.ownerId, 'spouse', 'spouseSuperAccount.ownerId');
+});
+
+test('SPOUSE-3: spouse accounts initialize with correct default balances', () => {
+  const { sim } = buildScenario();
+  const s = sim.state;
+
+  assert.strictEqual(s.spouseRothAccount.balance,  40_000,  'spouseRothAccount initial balance');
+  assert.strictEqual(s.spouseIraAccount.balance,   100_000, 'spouseIraAccount initial balance');
+  assert.strictEqual(s.spouseK401Account.balance,  150_000, 'spouseK401Account initial balance');
+  assert.strictEqual(s.spouseSuperAccount.balance, 125_000, 'spouseSuperAccount initial balance');
+});
+
+test('SPOUSE-4: spouse account balances grow independently after year-end earnings', () => {
+  const { sim } = buildScenario();
+  const initialSpouseRoth  = sim.state.spouseRothAccount.balance;
+  const initialPrimaryRoth = sim.state.rothAccount.balance;
+
+  // Advance to first earnings event (startOffset(1) means Dec 31 2027)
+  sim.stepTo(new Date(Date.UTC(2027, 11, 31)));
+
+  const spouseRothAfter  = sim.state.spouseRothAccount.balance;
+  const primaryRothAfter = sim.state.rothAccount.balance;
+
+  assert.ok(spouseRothAfter > initialSpouseRoth,
+    `spouseRothAccount should grow; was ${initialSpouseRoth}, now ${spouseRothAfter}`);
+  assert.ok(primaryRothAfter > initialPrimaryRoth,
+    `rothAccount should grow; was ${initialPrimaryRoth}, now ${primaryRothAfter}`);
+
+  // Each grows by its own rate × balance — they should grow independently
+  const spouseGrowth  = spouseRothAfter - initialSpouseRoth;
+  const primaryGrowth = primaryRothAfter - initialPrimaryRoth;
+  assert.ok(spouseGrowth > 0,  `spouse Roth growth should be positive; got ${spouseGrowth}`);
+  assert.ok(primaryGrowth > 0, `primary Roth growth should be positive; got ${primaryGrowth}`);
+  // Primary started with 80k, spouse with 40k; same rate → primary growth ~ 2× spouse growth
+  assert.ok(
+    Math.abs(primaryGrowth / spouseGrowth - 2) < 0.01,
+    `primaryGrowth (${primaryGrowth}) should be ~2× spouseGrowth (${spouseGrowth})`
+  );
+});
+
+test('SPOUSE-5: ROTH_EARNINGS_APPLY credits spouse account, not primary', () => {
+  // Set spouse balance to 0 so any earnings would be from primary only if routing is wrong.
+  const { sim } = buildScenario({ spouseRothBalance: 0, spouseRothBasis: 0 });
+
+  const initialPrimaryRoth = sim.state.rothAccount.balance;
+  sim.stepTo(new Date(Date.UTC(2027, 11, 31)));
+
+  // Primary should still grow; spouse should stay at 0 (no earnings on zero balance)
+  assert.ok(sim.state.rothAccount.balance > initialPrimaryRoth,
+    'primary rothAccount should grow regardless');
+  assert.strictEqual(sim.state.spouseRothAccount.balance, 0,
+    'spouseRothAccount with 0 balance should stay 0 — earnings must not leak to primary');
+});
+
+test('SPOUSE-6: serialize → deserialize round-trip preserves spouse accounts', () => {
+  const { scenario } = buildScenario();
+  const services = ServiceRegistry.getInstance();
+
+  const config = ScenarioSerializer.serialize(
+    services, 'Test',
+    new Date(Date.UTC(2026, 0, 1)), new Date(Date.UTC(2041, 0, 1)),
+    scenario.sim.state, {}
+  );
+
+  // Verify spouse accounts appear in serialized config
+  const accountNames = config.accounts.map(a => a.name);
+  assert.ok(accountNames.some(n => n.includes('Spouse') && n.includes('Roth')),
+    `Roth IRA (Spouse) missing from serialized accounts; got: ${accountNames}`);
+  assert.ok(accountNames.some(n => n.includes('Spouse') && n.includes('IRA')),
+    `Traditional IRA (Spouse) missing from serialized accounts`);
+  assert.ok(accountNames.some(n => n.includes('Spouse') && n.includes('401')),
+    `401(k) (Spouse) missing from serialized accounts`);
+  assert.ok(accountNames.some(n => n.includes('Spouse') && n.includes('Super')),
+    `Superannuation (Spouse) missing from serialized accounts`);
+
+  // Verify role is preserved in serialized data
+  const spouseRothData = config.accounts.find(a => a.name === 'Roth IRA (Spouse)');
+  assert.ok(spouseRothData, 'Roth IRA (Spouse) account data not found');
+  assert.strictEqual(spouseRothData.role,    'roth-ira', 'role should be preserved');
+  assert.strictEqual(spouseRothData.ownerId, 'spouse',   'ownerId should be preserved');
+
+  // Deserialize and verify accounts are restored
+  ServiceRegistry.reset();
+  const scenario2 = new IntlRetirementScenario({
+    eventSchedulerUI: makeStubUI(),
+    context: ServiceRegistry.getInstance().simulationContext,
+  });
+  scenario2.buildSim();
+  assert.doesNotThrow(
+    () => ScenarioSerializer.deserialize(config, ServiceRegistry.getInstance()),
+    'deserialize should not throw with spouse accounts'
+  );
+
+  const restoredAccounts = ServiceRegistry.getInstance().accountService.getAll();
+  const restoredNames = restoredAccounts.map(a => a.name);
+  assert.ok(restoredNames.some(n => n === 'Roth IRA (Spouse)'),
+    `Roth IRA (Spouse) not restored after deserialize; got: ${restoredNames}`);
+});

--- a/tests/unit/state-registry.test.mjs
+++ b/tests/unit/state-registry.test.mjs
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2026 Terry Packer.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * state-registry.test.mjs
+ *
+ * Unit tests for StateRegistry — role + ownerId based account lookup facade.
+ */
+
+import { test } from 'node:test';
+import assert   from 'node:assert/strict';
+
+import { StateRegistry }  from '../../src/finance/services/state-registry.js';
+import { AccountService } from '../../src/finance/services/account-service.js';
+import { Account, USD }   from '../../src/finance/assets/account.js';
+import { RothAccount, TraditionalIRAAccount } from '../../src/finance/assets/investment-account.js';
+import { ACCOUNT_ROLES }  from '../../src/finance/state/account-roles.js';
+import { EventBus }       from '../../src/simulation-framework/event-bus.js';
+import { Graph }          from '../../src/graph/graph.js';
+import { GraphQueryApi }  from '../../src/graph/graph-query-api.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeAccountService() {
+  const graph = new Graph();
+  return new AccountService(graph, new GraphQueryApi(graph), new EventBus());
+}
+
+/**
+ * Build a StateRegistry with the given accounts pre-registered.
+ * Simulates SimulationState._assignAccount by setting account.stateKey directly.
+ */
+function makeRegistry(accounts) {
+  const svc = makeAccountService();
+  const state = {};
+  for (const [key, account] of Object.entries(accounts)) {
+    account.stateKey = key;
+    svc.createAccount(account);
+    state[key] = account;
+  }
+  return { registry: new StateRegistry({ accountService: svc }), state };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test('StateRegistry.getAccount: returns account matching role + ownerId', () => {
+  const primaryRoth = new RothAccount(80_000, {
+    role:    ACCOUNT_ROLES.ROTH,
+    ownerId: 'primary',
+    country: 'US',
+    currency: USD,
+  });
+  const spouseRoth = new RothAccount(40_000, {
+    role:    ACCOUNT_ROLES.ROTH,
+    ownerId: 'spouse',
+    country: 'US',
+    currency: USD,
+  });
+  const { registry, state } = makeRegistry({
+    rothAccount:       primaryRoth,
+    spouseRothAccount: spouseRoth,
+  });
+
+  const found = registry.getAccount(state, ACCOUNT_ROLES.ROTH, 'primary');
+  assert.ok(found, 'should find primary roth account');
+  assert.strictEqual(found.balance, 80_000);
+});
+
+test('StateRegistry.getAccount: returns spouse account when ownerId=spouse', () => {
+  const primaryRoth = new RothAccount(80_000, {
+    role: ACCOUNT_ROLES.ROTH, ownerId: 'primary', country: 'US', currency: USD,
+  });
+  const spouseRoth = new RothAccount(40_000, {
+    role: ACCOUNT_ROLES.ROTH, ownerId: 'spouse', country: 'US', currency: USD,
+  });
+  const { registry, state } = makeRegistry({
+    rothAccount: primaryRoth, spouseRothAccount: spouseRoth,
+  });
+
+  const found = registry.getAccount(state, ACCOUNT_ROLES.ROTH, 'spouse');
+  assert.ok(found, 'should find spouse roth account');
+  assert.strictEqual(found.balance, 40_000);
+});
+
+test('StateRegistry.getAccount: ownerId=null matches first registered account', () => {
+  const acc = new Account(5_000, { role: ACCOUNT_ROLES.US_SAVINGS, country: 'US', currency: USD });
+  const { registry, state } = makeRegistry({ usSavingsAccount: acc });
+
+  const found = registry.getAccount(state, ACCOUNT_ROLES.US_SAVINGS, null);
+  assert.ok(found);
+  assert.strictEqual(found.balance, 5_000);
+});
+
+test('StateRegistry.getAccount: returns null for unknown role', () => {
+  const { registry, state } = makeRegistry({});
+  const found = registry.getAccount(state, 'nonexistent-role', null);
+  assert.strictEqual(found, null);
+});
+
+test('StateRegistry.getStateKey: returns stateKey matching role + ownerId', () => {
+  const primaryIra = new TraditionalIRAAccount(200_000, {
+    role: ACCOUNT_ROLES.IRA, ownerId: 'primary', country: 'US', currency: USD,
+  });
+  const spouseIra = new TraditionalIRAAccount(100_000, {
+    role: ACCOUNT_ROLES.IRA, ownerId: 'spouse', country: 'US', currency: USD,
+  });
+  const { registry } = makeRegistry({
+    iraAccount: primaryIra, spouseIraAccount: spouseIra,
+  });
+
+  assert.strictEqual(registry.getStateKey(ACCOUNT_ROLES.IRA, 'primary'), 'iraAccount');
+  assert.strictEqual(registry.getStateKey(ACCOUNT_ROLES.IRA, 'spouse'),  'spouseIraAccount');
+});
+
+test('StateRegistry.getStateKey: returns null for unknown role', () => {
+  const { registry } = makeRegistry({});
+  assert.strictEqual(registry.getStateKey('no-such-role', null), null);
+});
+
+test('StateRegistry.getAccounts: filters by country', () => {
+  const usAcc = new Account(10_000, { role: ACCOUNT_ROLES.US_SAVINGS, country: 'US', currency: USD });
+  const auAcc = new Account(20_000, { role: ACCOUNT_ROLES.AU_SAVINGS, country: 'AU', currency: 'AUD' });
+  const { registry, state } = makeRegistry({
+    usSavingsAccount: usAcc, auSavingsAccount: auAcc,
+  });
+
+  const usAccounts = registry.getAccounts(state, { country: 'US' });
+  assert.strictEqual(usAccounts.length, 1);
+  assert.strictEqual(usAccounts[0].balance, 10_000);
+
+  const auAccounts = registry.getAccounts(state, { country: 'AU' });
+  assert.strictEqual(auAccounts.length, 1);
+  assert.strictEqual(auAccounts[0].balance, 20_000);
+});
+
+test('StateRegistry.getAccounts: filters by role returning multiple owners', () => {
+  const primaryRoth = new RothAccount(80_000, {
+    role: ACCOUNT_ROLES.ROTH, ownerId: 'primary', country: 'US', currency: USD,
+  });
+  const spouseRoth = new RothAccount(40_000, {
+    role: ACCOUNT_ROLES.ROTH, ownerId: 'spouse', country: 'US', currency: USD,
+  });
+  const { registry, state } = makeRegistry({
+    rothAccount: primaryRoth, spouseRothAccount: spouseRoth,
+  });
+
+  const roths = registry.getAccounts(state, { role: ACCOUNT_ROLES.ROTH });
+  assert.strictEqual(roths.length, 2);
+  const balances = roths.map(a => a.balance).sort((a, b) => a - b);
+  assert.deepStrictEqual(balances, [40_000, 80_000]);
+});
+
+test('StateRegistry.getAccounts: filters by ownerId', () => {
+  const primaryRoth = new RothAccount(80_000, {
+    role: ACCOUNT_ROLES.ROTH, ownerId: 'primary', country: 'US', currency: USD,
+  });
+  const spouseRoth = new RothAccount(40_000, {
+    role: ACCOUNT_ROLES.ROTH, ownerId: 'spouse', country: 'US', currency: USD,
+  });
+  const primaryIra = new TraditionalIRAAccount(200_000, {
+    role: ACCOUNT_ROLES.IRA, ownerId: 'primary', country: 'US', currency: USD,
+  });
+  const { registry, state } = makeRegistry({
+    rothAccount: primaryRoth, spouseRothAccount: spouseRoth, iraAccount: primaryIra,
+  });
+
+  const spouseAccounts = registry.getAccounts(state, { ownerId: 'spouse' });
+  assert.strictEqual(spouseAccounts.length, 1);
+  assert.strictEqual(spouseAccounts[0].balance, 40_000);
+
+  const primaryAccounts = registry.getAccounts(state, { ownerId: 'primary' });
+  assert.strictEqual(primaryAccounts.length, 2);
+});
+
+test('StateRegistry.getAccounts: no filters returns all registered accounts present in state', () => {
+  const acc1 = new Account(1_000, { role: ACCOUNT_ROLES.US_SAVINGS, country: 'US', currency: USD });
+  const acc2 = new Account(2_000, { role: ACCOUNT_ROLES.AU_SAVINGS, country: 'AU', currency: 'AUD' });
+  const { registry, state } = makeRegistry({
+    usSavingsAccount: acc1, auSavingsAccount: acc2,
+  });
+
+  const all = registry.getAccounts(state);
+  assert.strictEqual(all.length, 2);
+});


### PR DESCRIPTION
State Registry - Decouple State fields from runtime logic

Account identity is currently expressed as plain JS property names on the state object (state.usSavingsAccount, state.stockAccount, etc.). The same string has to appear in at least 5 places for each account:

InternationalRetirementFinancialState constructor — where the property is assigned
Handler accountKey defaults — 'stockAccount', 'usSavingsAccount', etc.
Reducer accountKey defaults and direct string comparisons (targetKey === 'auSavingsAccount')
TaxPaymentDebitReducer — hard-codes 'auSavingsAccount' / 'usSavingsAccount' inline
ChangeResidencyApplyReducer.DEFAULT_INVESTMENT_KEYS — a literal array of all investment account key strings

Fixes #170